### PR TITLE
CI, and the first two post-launch fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,13 @@
+name: ci
+on: [push, pull_request]
+jobs:
+  verifie:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 24, cache: pnpm }
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - run: pnpm test

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ dist
 # config Claude Code personnelle, non partagee
 CLAUDE.local.md
 .claude/settings.local.json
+
+# carnet de travail interne, en francais et decrivant des bugs non corriges :
+# il vit sur le disque, rien n'en sort
+tasks/

--- a/docs/interface.md
+++ b/docs/interface.md
@@ -108,3 +108,15 @@ in `vw` alone its last character ended up off screen.
 `#etat=` is only written from the Animations view. Writing it elsewhere fired a
 `hashchange` that put the playhead back on the indices of the user's montage, while
 the settings view plays its own: the player stayed stuck on its entry state.
+
+Inside the view, the same `hashchange` had a second, worse effect. `locate()` looks
+the state up with a `findIndex`, so it returns its **first** occurrence. A montage
+with the same state twice — one click in the right-hand palette is enough — could
+therefore never get past the second one: reaching it wrote `#etat=idle`, the
+resulting `hashchange` read as an incoming navigation, and the playhead jumped back
+to the first `idle`. Pausing on the second occurrence did the same, through `&stop`.
+
+Hence `ecritParNous` in `App.vue`: the fragment we just wrote is remembered and its
+`hashchange` is ignored. It is **consumed** on that first read rather than kept —
+one write fires at most one event, and a browser Back to that same state later is a
+real navigation that must still move the playhead.

--- a/src/App.vue
+++ b/src/App.vue
@@ -226,6 +226,22 @@ watch(preview, (on) => {
 // qu'au changement, il faut l'appliquer aussi a l'initialisation.
 const playing = ref(intro.value || (initial.playing && view.value === 'animations'))
 
+/**
+ * Le dernier fragment que NOUS avons ecrit, en attente de son `hashchange`.
+ *
+ * Sans lui, le lecteur ne peut pas depasser un etat en DOUBLE dans le montage :
+ * `location.replace` declenche un `hashchange` que l'ecouteur traite comme une
+ * navigation entrante, et `locate` renvoie la PREMIERE occurrence de l'etat. Sur
+ * un montage ou `idle` apparait deux fois, atteindre la seconde ramenait la tete
+ * de lecture a la premiere — le montage bouclait sans jamais aboutir. Meme effet
+ * a la pause, qui ecrit `&stop`.
+ *
+ * Consomme a la premiere lecture : une ecriture provoque au plus un evenement,
+ * donc on ne doit pas ignorer durablement ce fragment — un retour arriere du
+ * navigateur vers ce meme etat est une vraie navigation, et elle doit compter.
+ */
+let ecritParNous = ''
+
 // L'URL est partageable, donc elle suit l'etat ET la lecture. replace et pas
 // push : on ne veut pas un cran d'historique par etat.
 watch([state, playing], ([id, on]) => {
@@ -235,10 +251,16 @@ watch([state, playing], ([id, on]) => {
   // qui replacait la tete de lecture sur les index du montage de l'utilisateur,
   // alors que la vue joue le sien : le lecteur restait coince sur l'orbite.
   if (view.value !== 'animations') return
-  location.replace(`#etat=${id}${on ? '' : '&stop'}`)
+  ecritParNous = `#etat=${id}${on ? '' : '&stop'}`
+  location.replace(ecritParNous)
 })
 
 window.addEventListener('hashchange', () => {
+  // notre propre ecriture n'est pas une navigation : cf. `ecritParNous`
+  if (location.hash === ecritParNous) {
+    ecritParNous = ''
+    return
+  }
   const next = readHash()
   /*
    * L'arrivee met en scene l'OUVERTURE de la page : la rejouer a chaud

--- a/src/components/BloubBot.vue
+++ b/src/components/BloubBot.vue
@@ -350,7 +350,18 @@ watch(block, (i) => {
 
 // Changement d'etat venu d'une prop : c'est le cas des vignettes figees, qui
 // n'ont pas de curseur. En lecture, `apply` a deja fait le travail.
+//
+// Le garde n'est pas une optimisation, il corrompait une image a CHAQUE jointure
+// de bloc a l'export : `rendAt` pose l'etat sur le moteur a son offset ABSOLU
+// puis echantillonne a la bonne date, mais le watcher — dont la file est videe
+// par le `nextTick` de l'export — repassait ensuite un `redrawFrozen()` non
+// inerte (le lecteur hors ecran est monte avec `frozenAt: 0`). Or `sample(0)`
+// juste apres un changement date a l'offset donne un ratio de melange nul, donc
+// la pose de l'etat PRECEDENT : le point d'exclamation revenait au depart de sa
+// course pendant une image, treize fois dans le montage par defaut.
 watch(state, (id) => {
+  // `rendAt` ou `apply` l'a deja applique, et a la bonne date
+  if (engine.state === id) return
   engine.setState(id, clock)
   redrawFrozen()
 })

--- a/src/ui/capture.ts
+++ b/src/ui/capture.ts
@@ -180,6 +180,15 @@ export async function cycleVersMp4(
  * trente secondes. La premiere passe ne retient que les couleurs, la seconde
  * encode — le rendu est deterministe, donc rejouer la sequence redonne exactement
  * les memes images.
+ *
+ * Un lecteur NEUF par passe, et c'est la condition de ce determinisme. Le moteur
+ * garde l'etat precedent pour ses fondus, et le lecteur garde le dernier bloc
+ * pose : rejouer l'image 0 sur le lecteur qui vient de finir la sequence datait
+ * le premier etat a l'instant 0 avec le DERNIER en etat precedent, et rendait
+ * donc la pose de celui-la. Le GIF par defaut s'ouvrait sur une boule sans yeux
+ * — la comete a un `eyeAlpha` nul — les yeux n'apparaissant qu'au fil des neuf
+ * images du fondu. La palette, elle, avait ete comptee sur des images qui
+ * n'etaient pas celles encodees.
  */
 export async function cycleVersGif(
   reglages: ReglagesBot,
@@ -190,31 +199,39 @@ export async function cycleVersGif(
   fond: string | null,
   avance?: Avancement
 ): Promise<Blob> {
+  // Un seul canvas pour les deux passes : il est reinitialise a chaque image.
   const canvas = document.createElement('canvas')
-  const lecteur = await ouvreCycle(reglages, blocs, taille, fond ?? undefined)
   const vue = viewBoxExport(DEMI_ECRAN)
-  const pixels = async (i: number) => {
-    const svg = await lecteur.rendre(i * pas)
-    const ctx = await dessine(svgAutonome(svg, taille, vue), taille, canvas, fond)
-    return ctx.getImageData(0, 0, taille, taille).data
-  }
-  try {
-    const palette = nouvellePalette()
-    for (let i = 0; i < images; i++) {
-      recense(palette, await pixels(i))
-      avance?.(i + 1, images * 2)
+
+  /** Une passe complete sur la sequence, sur un lecteur neuf. */
+  const passe = async (lis: (index: number, pixels: Uint8ClampedArray) => void) => {
+    const lecteur = await ouvreCycle(reglages, blocs, taille, fond ?? undefined)
+    try {
+      for (let i = 0; i < images; i++) {
+        const svg = await lecteur.rendre(i * pas)
+        const ctx = await dessine(svgAutonome(svg, taille, vue), taille, canvas, fond)
+        lis(i, ctx.getImageData(0, 0, taille, taille).data)
+      }
+    } finally {
+      lecteur.ferme()
     }
-    const morceaux: Uint8Array[] = []
-    for (let i = 0; i < images; i++) {
-      morceaux.push(indexe(palette, await pixels(i)))
-      avance?.(images + i + 1, images * 2)
-    }
-    return new Blob([gifIndexe(palette, morceaux, taille, taille, Math.round(pas * 1000))], {
-      type: 'image/gif'
-    })
-  } finally {
-    lecteur.ferme()
   }
+
+  const palette = nouvellePalette()
+  await passe((i, pixels) => {
+    recense(palette, pixels)
+    avance?.(i + 1, images * 2)
+  })
+
+  const morceaux: Uint8Array[] = []
+  await passe((i, pixels) => {
+    morceaux.push(indexe(palette, pixels))
+    avance?.(images + i + 1, images * 2)
+  })
+
+  return new Blob([gifIndexe(palette, morceaux, taille, taille, Math.round(pas * 1000))], {
+    type: 'image/gif'
+  })
 }
 
 /** Ce que le bot doit porter sur l'animation exportee. */
@@ -314,6 +331,16 @@ export async function ouvreCycle(
         ...reglages,
         size: taille,
         cycle: blocs,
+        /*
+         * Le moteur se construit sur l'etat qu'on lui donne, et l'image 0 doit
+         * etre le PREMIER etat du montage. Sans cette prop le modele prenait son
+         * defaut `idle` : un montage commencant par l'orbite s'ouvrait sur une
+         * boule au repos qui morphait vers le triangle pendant 0,6 s. C'est la
+         * meme precaution qu'a l'ecran, ou `state` est amorce sur le bloc courant
+         * « pour ne pas entrer en morphant depuis un etat qui n'a jamais ete
+         * affiche » (cf. `App.vue`).
+         */
+        state: blocs[0]?.state ?? 'idle',
         frozenAt: 0,
         ref: bot,
         ...(paper ? { paper } : {})


### PR DESCRIPTION
Sets up continuous integration — the repository had no `.github/workflows` at all, so a pull request checked nothing — and brings the first two fixes from the post-launch audit.

- **CI** (`ci.yml`): `pnpm install --frozen-lockfile`, `pnpm build`, `pnpm test` on every push and pull request.
- **Player loop on a duplicate state.** Writing `#etat=` fired a `hashchange` that the listener read as an incoming navigation, and `locate()` returns the *first* occurrence of a state. A montage holding the same state twice — one click in the palette — could never get past the second one. The fragment we write is now remembered and its own event ignored, consumed on first read so a browser Back still counts.
- **Three image defects in the montage export.** One corrupt frame at every block joint (measured: the eye trajectory jumped up to 53.4 units, now 0.6 max), the GIF opening on an eyeless ball (the two passes shared one player, so pass 2 replayed frame 0 with the last state as the previous one), and a montage not starting on `idle` fading in from the resting pose anyway.

`pnpm build` and `pnpm test` (178 tests) pass on each of the three commits.

Merged without squash on purpose: the commits are atomic, so a single fix can be reverted on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)