### PR TITLE
Eye margin on non-circular customiser shapes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,18 @@ Details and the reasoning behind each are in [docs/](docs/):
 - **Anything sitting "on" the body must follow its real radius**: `radiusAtAngle`
   (defined in `shape.ts`, applied by `engine.ts`) for the eyes and the notification
   pastille. A new element anchored to the outline needs the same treatment.
+- **That pro-rata places the eye's centre, not the eye.** Since the margin in front of the
+  edge is multiplied by the same factor, a narrow shape pushed the eye out through the mask.
+  `src/bot/eyefit.ts` adds a **common offset to both eyes** — a translation, so an isometry —
+  only on a customiser shape. **It is a table built at import, not a solver in the render
+  loop**, and that distinction *is* the fix: seven per-frame versions all trembled, because
+  everything they read (gaze drift, pointer, expression mid-morph, which edge is nearest)
+  moves every frame. The engine reads the table on the **boundaries** of each morph and
+  interpolates with that morph's own curve — never on the interpolated value, which has no
+  identity and exists in no table. `docs/architecture.md` lists the six variants that were
+  measured and rejected; don't re-try them. `skins.test.ts` locks the lot, and it sweeps
+  **time as well as combinations** — one instant per combination is what let
+  `capsule` + `effraye` through.
 - **States declare `ArcSpec`; only the engine rasterises.** Don't call `arcRender`
   from `states.ts`.
 - **Transitions are exponential ease-outs and the body never overshoots.** The one

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,6 +66,92 @@ silhouette and the mask cuts them. Hence `radiusAtAngle`, defined in `shape.ts`,
 applied by `engine.ts` to the eyes and to the notification pastille. Any new
 element anchored to the outline needs the same treatment.
 
+That pro-rata places the eye's **centre** correctly, and that is not enough: the eye
+has a size, and the margin left in front of the edge gets multiplied by the same
+pro-rata. A shape that is narrow in the eye's direction therefore pushed it against
+the edge until the mask opened it outwards — the capsule, the triangle, the cloud and
+the teardrop all did, 55 shape × expression × state combinations out of 680, up to
+11.6 units on a ball of radius 100.
+
+So a **common offset** is added to both eyes, only when a customiser shape has replaced
+the body. It is a translation and nothing else, hence an isometry: spacing, sizes and
+tilts are all preserved to the pixel. The face simply sits a little lower on a body that
+has no room up there — the gesture you would make by hand.
+
+### The offset is a table, not a solver
+
+This is the whole fix, far more than the geometry it contains. `src/bot/eyefit.ts` solves
+the problem **once, at import**, and yields one entry per (shape, base-body state,
+expression).
+
+Seven versions solved it inside the render loop instead, and every one of them produced a
+visible motion artefact, because everything the solver reads moves at sixty frames per
+second: the resting gaze drift, the pointer, the expression mid-morph, which edge is
+nearest, which eye is tightest. The names for what went wrong are established ones — an
+**active-set change** when the nearest edge switches (26 units of backtracking), a
+**non-smooth objective** because `min` is C0 but not C1, and **chattering** from a
+per-frame feedback loop. The defect was in none of their geometries; it was in solving per
+frame.
+
+The rest of the engine does not work that way: poses are **declared** and it only
+interpolates them along known curves. A tabulated offset fits that mould, and the engine
+reads the table on the **boundaries** of each morph — `shapePrev`/`shape`,
+`exprPrev`/`expr`, `prev`/`cur` — then interpolates with that morph's own `easeOutQuint`.
+Never on the interpolated value: during a shape morph `shapeAtTime` allocates a fresh array
+with no identity, and `blendExpression` already carries the target's id, so neither exists
+in any table. Feeding those to the solver is exactly what made the eyes tremble.
+
+The same approach has a name in character rigging: **pose space deformation** (Lewis,
+Cordner & Fong, SIGGRAPH 2000) — a corrective authored per pose, resolved at setup and
+merely looked up at runtime.
+
+A pleasant corollary: the solver no longer has any continuity requirement, since it doesn't
+run during the animation. It can therefore iterate to convergence and take the worst case
+over everything that varies — the gaze drift included, whose analytic bounds it covers.
+A per-frame version could afford neither.
+
+The table is a module constant built from pure data, the same nature as the pre-drawn blink
+schedule in `face.ts`: deterministic and stateless, so `engine.sample(t)` stays a pure
+function of time.
+
+### What not to try again
+
+Each of these was written and measured, and each broke something visible:
+
+- **Bounding per eye.** The two eyes don't aim in the same direction, so they don't retreat
+  by the same amount: the pair spreads, and a distorted face reads far worse than the
+  clipping being fixed.
+- **Retreating radially towards the centre.** That travels a long diagonal to gain a little
+  vertical room, so aiming for the circle's margin dragged both eyes to the middle where
+  they merged into one blob — 283 combinations out of 680.
+- **Scaling the face.** Scaling position *and* eye size keeps every ratio and is stable,
+  but the eyes get visibly smaller on a flat body and a change of expression then animates
+  that resize. `skins.test.ts` locks the eye's `d` against it.
+- **Taking the worst eye.** `Math.min` over the two is a discrete choice: the binding eye
+  changes mid-morph and the push direction flips with it, 11.6 units on the triangle whose
+  two slanted edges compete for the pair.
+- **One entry per shape, worst case over expressions.** Tempting, since a constant offset
+  cannot move when the expression changes — but on a capsule `neutre` has its eyes high and
+  needs to go down while `effraye` has them low and needs to go up. No single translation
+  satisfies both, measured: 4 combinations still overflowing.
+- **Giving up when nothing fits.** `wide` has 87-unit gélules and `notify` 50-unit ones; on
+  a triangle or a teardrop they overflow whatever you do, and "no worse than the circle" is
+  then satisfied degenerately. The rule is to aim for the least bad, never to leave a real
+  overflow unimproved.
+
+The margin aimed for is the one the **original profile** gave, not clearance: on the circle
+the outer eye already grazes the edge and that is deliberate, it is what gives the volume.
+Aiming for clearance left the eye exactly tangent, which shows. On the circle both outlines
+are the same, so the offset is `0, 0` by construction and the reference does not move —
+which is also what protects `public/favicon.svg`.
+
+`src/bot/skins.test.ts` locks all of it. It measures back-and-forths frame by frame rather
+than speed — a morph moves the eyes fast anyway, trembling is going *and coming back* — it
+separates what would tremble permanently (resting drift, shape morph: no more than the
+circle) from a change of expression, and it sweeps **time as well as combinations**: one
+instant per combination is what let `capsule` + `frightened` through, since it was the
+resting drift that carried the eye over the edge.
+
 ## States declare `ArcSpec`, the engine rasterises
 
 Geometry in `ArcSpec` is expressed in ball-radius units; only the engine knows the

--- a/src/bot/engine.ts
+++ b/src/bot/engine.ts
@@ -1,5 +1,6 @@
 import { arcRender, type ArcRender, type DotRender } from './decor'
 import { blendExpression, type BotExpression } from './expressions'
+import { decalageDesYeux } from './eyefit'
 import { blinkScale, eyePoses, liveliness } from './face'
 import { clamp, easings, lerp, r2 } from './math'
 import {
@@ -277,6 +278,56 @@ export class BotEngine {
     return pose
   }
 
+  /**
+   * Decalage des yeux a l'instant `now` pour un etat donne, en unites de rayon de boule.
+   *
+   * Il est LU dans une table et interpole, jamais recalcule : `eyefit.ts` explique
+   * pourquoi cette distinction est tout le correctif. Ici il ne reste qu'a l'interpoler
+   * sur l'axe de la forme, avec exactement la courbe et la duree du morph de silhouette
+   * — c'est la meme cause, donc ce doit etre le meme mouvement.
+   *
+   * On interroge la table sur les BORNES du morph (`shapePrev` et `shape`) et non sur le
+   * profil que rend `shapeAtTime` : celui-la est un tableau neuf alloue a chaque image,
+   * donc sans identite, et il n'existe dans aucune table.
+   */
+  private decalageAtTime(now: number, state: StateId): { x: number; y: number } {
+    /**
+     * Un axe de morph : on lit la table sur ses deux BORNES et on interpole avec sa
+     * courbe. Jamais sur la valeur interpolee — celle-la n'a pas d'identite et n'existe
+     * dans aucune table, et c'est en la lui donnant a manger que les versions
+     * precedentes tremblaient.
+     */
+    const surAxe = (
+      debut: number,
+      duree: number,
+      a: { x: number; y: number },
+      b: { x: number; y: number }
+    ) => {
+      if (a === b) return b
+      const k = (now - debut) / duree
+      if (k >= 1) return b
+      const t = easings.easeOutQuint(clamp(k))
+      return { x: lerp(a.x, b.x, t), y: lerp(a.y, b.y, t) }
+    }
+
+    // axe de l'expression, pour chacune des deux formes en presence
+    const parForme = (radii: number[] | null) =>
+      surAxe(
+        this.exprAt,
+        BotEngine.SHAPE_MORPH,
+        decalageDesYeux(radii, state, this.exprPrev?.id ?? null),
+        decalageDesYeux(radii, state, this.expr?.id ?? null)
+      )
+
+    // puis axe de la forme
+    return surAxe(
+      this.shapeAt,
+      BotEngine.SHAPE_MORPH,
+      parForme(this.shapePrev),
+      parForme(this.shape)
+    )
+  }
+
   get state(): StateId {
     return this.cur
   }
@@ -297,6 +348,7 @@ export class BotEngine {
     const shape = this.shapeAtTime(now)
     const expr = this.exprAtTime(now)
     let pose = this.posed(def, Math.max(0, now - this.tCur), shape, expr)
+    let decalage = this.decalageAtTime(now, this.cur)
 
     // --- transition -------------------------------------------------------
     const since = now - this.tCur
@@ -312,7 +364,14 @@ export class BotEngine {
       // Le ratio est borne : relire une date ANTERIEURE au changement d'etat
       // donnerait un ratio negatif, que l'ease-out extrapole — la silhouette
       // part alors trente fois trop loin.
-      pose = blendPose(prevPose, pose, easings.easeOutQuint(clamp(since / def.morph)))
+      const ratio = easings.easeOutQuint(clamp(since / def.morph))
+      pose = blendPose(prevPose, pose, ratio)
+      // le decalage des yeux suit la MEME courbe que la silhouette qui le motive
+      const avant = this.decalageAtTime(now, this.prev)
+      decalage = {
+        x: lerp(avant.x, decalage.x, ratio),
+        y: lerp(avant.y, decalage.y, ratio)
+      }
     }
 
     // --- vie au repos -----------------------------------------------------
@@ -379,7 +438,7 @@ export class BotEngine {
         const k = blinkScale(Math.min(lid, cfg.open))
         eyes.push({
           d: capsulePath(cfg.w * R, cfg.h * R),
-          matrix: `matrix(${r2(ax)},${r2(ay * k)},${r2(cx2)},${r2(cy2 * k)},${r2(e.x * fit + offX * R)},${r2(e.y * fit + offY * R)})`,
+          matrix: `matrix(${r2(ax)},${r2(ay * k)},${r2(cx2)},${r2(cy2 * k)},${r2(e.x * fit + (offX + decalage.x) * R)},${r2(e.y * fit + (offY + decalage.y) * R)})`,
           alpha: pose.eyeAlpha * clamp(e.depth / 0.12)
         })
       }

--- a/src/bot/eyefit.ts
+++ b/src/bot/eyefit.ts
@@ -1,0 +1,455 @@
+/**
+ * Ou poser le visage sur une forme du personnalisateur.
+ *
+ * Les yeux vivent sur une sphere, et `radiusAtAngle` les recolle au contour reel au
+ * prorata du rayon local. Ce prorata place bien leur CENTRE, mais l'oeil a une taille :
+ * la marge qui lui reste devant le bord est multipliee par le meme facteur, donc une
+ * silhouette etroite dans sa direction le pousse contre le bord jusqu'a ce que le
+ * masque l'ouvre vers l'exterieur. La gelule apparaissait comme une encoche dans le
+ * corps sur `capsule`, `triangle`, `nuage` et `goutte`.
+ *
+ * Ce module resout le probleme UNE FOIS, au chargement, et rend une table de decalages.
+ * Ce choix est l'essentiel du correctif, bien plus que la geometrie qui suit :
+ *
+ * Resolue dans la boucle de rendu, la correction reagit a tout ce qui bouge a soixante
+ * images par seconde — la derive du regard, le pointeur, l'expression en cours de
+ * morph, le bord le plus proche qui change, l'oeil le plus contraint qui change. Sept
+ * variantes ont ete ecrites ainsi et toutes produisaient un artefact de mouvement
+ * visible : tremblement permanent, saut de direction de 26 unites quand le bord de
+ * reference basculait, grossissement brusque quand la taille entrait dans le calcul.
+ * Le defaut n'etait dans aucune de leurs geometries, il etait dans le fait de resoudre
+ * par image.
+ *
+ * Le reste du moteur ne travaille pas comme ca : les poses sont DECLAREES et il ne fait
+ * que les interpoler avec des courbes connues. Un decalage tabule rentre dans ce moule.
+ * Il ne bouge pas quand le regard derive ni quand le pointeur bouge, et sur un changement
+ * de forme ou d'expression il ne fait qu'aller d'une entree de table a l'autre, sur la
+ * courbe de ce morph. Le tremblement devient impossible par construction, au lieu d'etre
+ * repousse : interpoler entre deux constantes est monotone, alors que re-resoudre le
+ * probleme sur un regard en cours d'interpolation ne l'est pas.
+ *
+ * Corollaire agreable : le solveur n'a plus aucune contrainte de continuite, puisqu'il ne
+ * tourne pas pendant l'animation. Il peut donc sonder tout un faisceau de directions et
+ * couvrir le pire cas de la derive du regard, ce qu'une version par image ne pouvait pas
+ * se permettre.
+ *
+ * La table est une constante de module, batie a l'import a partir de donnees pures :
+ * meme nature que le calendrier de clignements de `face.ts`, deterministe et sans etat,
+ * donc sans effet sur la purete de `engine.sample(t)`.
+ */
+
+import { EXPRESSIONS, type BotExpression } from './expressions'
+import { eyePoses } from './face'
+import { radiusAtAngle, toPoints, type Point } from './shape'
+import { SHAPES } from './skins'
+import { STATES, type Pose, type StateDef, type StateId } from './states'
+
+/** Rayon de reference du solveur. Le decalage rendu est en unites de ce rayon. */
+const R = 100
+
+/**
+ * Amplitudes maximales de la vie au repos, lues sur `liveliness` : `loopNoise` est
+ * borne a 1 en valeur absolue, donc ces sommes sont des bornes exactes et non des
+ * estimations.
+ *
+ * Il faut les couvrir, sinon la correction est juste sur la pose nominale et fausse une
+ * seconde plus tard : 7 degres de lacet deplacent l'oeil d'une douzaine d'unites sur une
+ * boule de rayon 100. C'est precisement ce qui faisait deborder `capsule` + `effraye`
+ * alors qu'une mesure a un seul instant le declarait bon.
+ */
+const DERIVE_YAW = 5.5 + 1.6
+const DERIVE_PITCH = 4.2 + 1.3
+/** Flottement du centre, en unites de rayon de boule. */
+const DERIVE_X = 0.006
+const DERIVE_Y = 0.007
+
+/** Le visage d'une pose, ce dont le solveur a besoin pour placer ses gelules. */
+interface Visage {
+  gaze: Pose['gaze']
+  split: number
+  eyes: Pose['eyes']
+}
+
+/**
+ * Une gelule prete a etre mesuree : le segment de son axe, et de quoi calculer le rayon
+ * a degager DANS UNE DIRECTION donnee.
+ *
+ * Une gelule est exactement un segment epaissi d'un disque de rayon `r`. Son image par la
+ * matrice tangente est donc un segment epaissi d'une ELLIPSE, et le rayon a degager
+ * depend de la direction : c'est la fonction d'appui de cette ellipse, `r * |A^T u|`.
+ *
+ * Prendre a la place sa plus grande valeur singuliere serait conservateur mais faux dans
+ * la seule direction qui compte, et ca se paie cher : la marge de reference sur le cercle
+ * ressortait NEGATIVE, donc la demande devenait sans dents et 34 combinaisons
+ * continuaient de deborder.
+ */
+interface Empreinte {
+  /** centre, en unites de viewBox */
+  x: number
+  y: number
+  /** demi-vecteur de l'axe */
+  ax: number
+  ay: number
+  /** rayon du disque local, avant transformation */
+  r: number
+  /** colonnes de la matrice tangente, pour la fonction d'appui */
+  m: [number, number, number, number]
+}
+
+/**
+ * Empreintes des deux yeux d'un visage, posees sur un profil.
+ *
+ * Une gelule est exactement un segment epaissi d'un disque de rayon `r`. Son image par
+ * la matrice tangente est donc un segment epaissi d'une ELLIPSE, et un disque du rayon
+ * de son grand axe la couvre : d'ou la plus grande valeur singuliere. La mesure reste
+ * ainsi conservatrice au sens strict, une marge positive garantissant que la gelule est
+ * dedans.
+ *
+ * Le clignement n'y est pas : un oeil ferme n'a pas besoin qu'on lui fasse de la place.
+ */
+function empreintes(visage: Visage, sil: Pose['sil'], radii: number[]): Empreinte[] {
+  const out: Empreinte[] = []
+  const poses = eyePoses(visage.gaze, R, visage.split)
+  for (let i = 0; i < 2; i++) {
+    const e = poses[i]!
+    if (e.depth <= 0.02) continue
+    const cfg = visage.eyes[i]!
+    const phi = ((cfg.tilt ?? 0) * Math.PI) / 180
+    const cp = Math.cos(phi)
+    const sp = Math.sin(phi)
+    const ax = e.a * cp + e.c * sp
+    const ay = e.b * cp + e.d * sp
+    const cx = -e.a * sp + e.c * cp
+    const cy = -e.b * sp + e.d * cp
+
+    const hw = Math.max(cfg.w * R, 0.01) / 2
+    const hh = Math.max(cfg.h * R, 0.01) / 2
+    const r = Math.min(hw, hh)
+    // l'axe est celui de la plus grande dimension
+    const long = hh > hw
+    const demi = long ? hh - r : hw - r
+    // le prorata du rayon local, exactement comme le fait le moteur
+    const fit = radiusAtAngle(radii, Math.atan2(e.y, e.x) - sil.rot)
+    out.push({
+      x: e.x * fit,
+      y: e.y * fit,
+      ax: (long ? cx : ax) * demi,
+      ay: (long ? cy : ay) * demi,
+      r,
+      m: [ax, ay, cx, cy]
+    })
+  }
+  return out
+}
+
+/**
+ * Approche la plus courte entre un contour et un segment : la distance, et le vecteur
+ * qui va du contour vers le segment — le sens qui degage.
+ *
+ * Les deux sortent de la MEME passe. Les calculer separement doublait le seul vrai cout
+ * de ce module, qui est ce balayage.
+ */
+function approche(pts: Point[], x0: number, y0: number, x1: number, y1: number) {
+  const sx = x1 - x0
+  const sy = y1 - y0
+  const len2 = sx * sx + sy * sy
+  let best = Infinity
+  let vx = 0
+  let vy = 0
+  for (let i = 0; i < pts.length; i++) {
+    const p = pts[i]!
+    let t = len2 > 0 ? ((p.x - x0) * sx + (p.y - y0) * sy) / len2 : 0
+    t = t < 0 ? 0 : t > 1 ? 1 : t
+    const ex = x0 + t * sx - p.x
+    const ey = y0 + t * sy - p.y
+    const d2 = ex * ex + ey * ey
+    if (d2 < best) {
+      best = d2
+      vx = ex
+      vy = ey
+    }
+  }
+  const d = Math.sqrt(best)
+  return { d, ux: d > 1e-9 ? vx / d : 0, uy: d > 1e-9 ? vy / d : 0 }
+}
+
+/** Une epreuve : des gelules a faire tenir dans un contour, et le contour de reference. */
+interface Epreuve {
+  empreintes: Empreinte[]
+  reference: Empreinte[]
+  contour: Point[]
+  calContour: Point[]
+}
+
+/**
+ * Flottement du centre au repos, en unites de viewBox. Il est ajoute au rayon de la
+ * gelule : moins d'une unite, donc l'absorber ainsi coute moins cher que de multiplier les
+ * epreuves par ses quatre coins.
+ */
+const FLOTTEMENT = Math.hypot(DERIVE_X, DERIVE_Y) * R
+
+/** Marge de la gelule la plus serree, et le sens qui la degage. */
+function pire(pts: Point[], emps: Empreinte[], tx: number, ty: number) {
+  let marge = Infinity
+  let ux = 0
+  let uy = 0
+  for (const e of emps) {
+    const x = e.x + tx
+    const y = e.y + ty
+    const a = approche(pts, x - e.ax, y - e.ay, x + e.ax, y + e.ay)
+    // fonction d'appui de l'ellipse dans la direction de l'approche
+    const [m0, m1, m2, m3] = e.m
+    const rayon =
+      e.r * Math.hypot(m0 * a.ux + m1 * a.uy, m2 * a.ux + m3 * a.uy) + FLOTTEMENT
+    if (a.d - rayon < marge) {
+      marge = a.d - rayon
+      ux = a.ux
+      uy = a.uy
+    }
+  }
+  return { marge, ux, uy }
+}
+
+/**
+ * Directions sondees et pas de la dichotomie. Le produit des deux est le cout de
+ * construction de la table, seul chiffre a surveiller ici.
+ */
+const DIRECTIONS = 12
+const DICHOTOMIE = 8
+
+/**
+ * Le decalage a poser sur les deux yeux pour cette forme, cet etat et cette expression.
+ *
+ * Une TRANSLATION commune aux deux yeux, donc une isometrie : ecart entre les yeux,
+ * tailles et inclinaisons sont conserves au pixel. Le visage est seulement pose un peu
+ * plus bas sur un corps qui n'a pas de place en haut, ce qui est le geste qu'on ferait a
+ * la main. Les variantes qui bornaient chaque oeil separement ecartaient la paire, et
+ * celles qui mettaient le visage a l'echelle rapetissaient les yeux — visiblement.
+ *
+ * La marge visee est celle du profil D'ORIGINE, pas un degagement strict : sur le cercle
+ * l'oeil exterieur frole deja le bord, 17,3 unites pour une boule de rayon 100, et c'est
+ * voulu, c'est ce qui donne le volume. Elle est plafonnee par ce que la forme offre en son
+ * centre, sinon la demande est intenable sur un corps plat.
+ *
+ * RECHERCHE DIRECTIONNELLE et non descente. On cherche la translation de plus petite
+ * norme qui tient, donc on sonde une couronne de directions et on dichotomie la distance
+ * le long de chacune. Une descente de gradient a ete ecrite d'abord et elle ne converge
+ * pas : degager la paire d'un bord la rapproche de l'autre, si bien qu'elle tatonne et ne
+ * fait que garder son meilleur essai — passer ses tours de 40 a 18 suffisait a faire
+ * reapparaitre 34 debordements. Ici le resultat ne depend pas d'une convergence : chaque
+ * direction est resolue exactement, au pas de dichotomie pres.
+ */
+function resous(epreuves: Epreuve[]): { x: number; y: number } {
+  if (!epreuves.length) return { x: 0, y: 0 }
+
+  /** La marge la plus serree sur toutes les epreuves, pour une translation donnee. */
+  const marge = (tx: number, ty: number) => {
+    let m = Infinity
+    for (const ep of epreuves) m = Math.min(m, pire(ep.contour, ep.empreintes, tx, ty).marge)
+    return m
+  }
+
+  // Marge exigee : la plus serree que le profil d'origine tolere, sur toutes les
+  // epreuves. Puis plafonnee par le plus degage que la forme puisse offrir a la paire,
+  // son centre.
+  let requis = Infinity
+  for (const ep of epreuves) {
+    requis = Math.min(requis, pire(ep.calContour, ep.reference, 0, 0).marge)
+  }
+  /*
+   * La course doit pouvoir atteindre le centre du corps : `wide` a des gelules de 87
+   * unites de long, et sur un triangle elles ne tiennent que vers le milieu, a une
+   * cinquantaine d'unites de leur place nominale. Une course fixe les laissait dehors.
+   */
+  let mx = 0
+  let my = 0
+  const emps = epreuves[0]!.empreintes
+  for (const e of emps) {
+    mx -= e.x / emps.length
+    my -= e.y / emps.length
+  }
+  const course = Math.max(0.35 * R, Math.hypot(mx, my) * 1.25)
+
+  // Plafond de la demande : ce que la forme offre en son centre, toujours atteignable.
+  requis = Math.min(requis, marge(mx, my))
+
+  /*
+   * Deja bon : le cas du cercle, et de toute forme assez large. La gelule doit RENTRER
+   * en plus de n'etre pas plus serree que sur le profil d'origine — sans cette seconde
+   * condition, une forme ou rien ne rentre satisfait la premiere de facon degeneree et
+   * on abandonnait. `wide` a des gelules de 87 unites de long, `notify` de 50 de
+   * diametre : sur un triangle ou une goutte elles debordent quoi qu'on fasse, et il
+   * faut alors viser le moins pire, pas renoncer.
+   */
+  const depart = marge(0, 0)
+  if (depart >= requis && depart >= 0) return { x: 0, y: 0 }
+  const cible = Math.max(requis, 0)
+
+  let meilleurX = 0
+  let meilleurY = 0
+  let meilleureNorme = Infinity
+  // repli quand rien ne rentre : la translation qui degage le plus, sondee au passage
+  let secoursX = 0
+  let secoursY = 0
+  let secours = depart
+
+  for (let d = 0; d < DIRECTIONS; d++) {
+    const a = (d / DIRECTIONS) * Math.PI * 2
+    const ux = Math.cos(a)
+    const uy = Math.sin(a)
+    if (marge(ux * course, uy * course) < cible) {
+      // cette direction ne mene nulle part ; on garde quand meme le meilleur degagement
+      // pas de solution par la, mais peut-etre un meilleur degagement
+      for (const k of [0.3, 0.6, 1]) {
+        const m = marge(ux * course * k, uy * course * k)
+        if (m > secours) {
+          secours = m
+          secoursX = ux * course * k
+          secoursY = uy * course * k
+        }
+      }
+      continue
+    }
+    // la plus courte distance qui tient, le long de cette direction
+    let bas = 0
+    let haut = course
+    for (let i = 0; i < DICHOTOMIE; i++) {
+      const mid = (bas + haut) / 2
+      if (marge(ux * mid, uy * mid) >= cible) haut = mid
+      else bas = mid
+    }
+    if (haut < meilleureNorme) {
+      meilleureNorme = haut
+      meilleurX = ux * haut
+      meilleurY = uy * haut
+    }
+  }
+
+  const x = meilleureNorme === Infinity ? secoursX : meilleurX
+  const y = meilleureNorme === Infinity ? secoursY : meilleurY
+  // rendu en unites de RAYON DE BOULE : le moteur le remet a son echelle
+  return { x: +(x / R).toFixed(6), y: +(y / R).toFixed(6) }
+}
+
+/**
+ * Le visage a couvrir : celui de l'expression si l'etat l'accepte, le sien sinon.
+ *
+ * UNE entree de table par expression, et non un pire cas commun a toutes. Un pire cas
+ * paraissait plus sur — un decalage constant ne peut pas bouger quand l'expression change
+ * — mais il est intenable : sur une capsule, `neutre` a les yeux hauts et demande a
+ * descendre quand `effraye` les a bas et demande a monter. Aucune translation unique ne
+ * satisfait les deux, et la mesure le confirme (4 debordements de 4,8 unites).
+ *
+ * Une entree par expression n'est pas moins fluide pour autant : le moteur interpole
+ * entre DEUX CONSTANTES, ce qui est monotone par construction. Ce qui tremblait, c'etait
+ * de re-resoudre le probleme sur un regard en cours d'interpolation.
+ */
+function visageDe(def: StateDef, pose: Pose, expr: BotExpression | null): Visage {
+  if (def.baseFace && expr) return { gaze: expr.gaze, split: expr.split, eyes: expr.eyes }
+  return { gaze: pose.gaze, split: pose.split, eyes: pose.eyes }
+}
+
+/** Les dates a echantillonner dans un etat : une seule si sa pose ne bouge pas. */
+function dates(def: StateDef): number[] {
+  /** Tout ce dont le solveur se sert : si rien ne bouge, une date suffit. */
+  const signature = (p: Pose) =>
+    JSON.stringify([p.gaze, p.split, p.eyes, p.sil.rot, p.sil.cx, p.sil.cy, p.sil.sx, p.sil.sy])
+  if (signature(def.pose(0)) === signature(def.pose(def.duration))) return [0]
+  const n = 3
+  return Array.from({ length: n }, (_, i) => (i / (n - 1)) * def.duration)
+}
+
+/** Le decalage d'une forme sur un etat et une expression, derive comprise. */
+function decalagePour(
+  def: StateDef,
+  radii: number[],
+  expr: BotExpression | null
+): { x: number; y: number } {
+  const epreuves: Epreuve[] = []
+  for (const t of dates(def)) {
+    const pose = def.pose(t)
+    const contour = toPoints({ ...pose.sil, radii }, R)
+    const calContour = toPoints(pose.sil, R)
+    const v = visageDe(def, pose, expr)
+    // Les quatre coins de la derive bornent la pose nominale, qui est leur centre : la
+    // tester en plus ne changerait aucune marge et coute une epreuve sur cinq.
+    const coins: Visage[] = []
+    for (const dy of [-DERIVE_YAW, DERIVE_YAW]) {
+      for (const dp of [-DERIVE_PITCH, DERIVE_PITCH]) {
+        coins.push({
+          ...v,
+          gaze: { yaw: v.gaze.yaw + dy, pitch: v.gaze.pitch + dp, roll: v.gaze.roll }
+        })
+      }
+    }
+    for (const c of coins) {
+      epreuves.push({
+        empreintes: empreintes(c, pose.sil, radii),
+        reference: empreintes(c, pose.sil, pose.sil.radii),
+        contour,
+        calContour
+      })
+    }
+  }
+  return resous(epreuves)
+}
+
+/** Zero, la valeur commune a tout ce qui n'a rien a corriger. */
+const NUL = { x: 0, y: 0 } as const
+
+/** Clef d'une entree : l'etat, et l'expression quand l'etat l'accepte. */
+const clef = (state: StateId, expr: string | null) => `${state}|${expr ?? ''}`
+
+/**
+ * Table des decalages, batie a l'import : une entree par (forme, etat a corps de base,
+ * expression). Seuls `idle` et `swirl` portent le visage de repos, donc seuls eux se
+ * declinent par expression — les trois autres etats a corps de base ont un visage releve
+ * sur la video et une seule entree.
+ *
+ * Clef par REFERENCE du tableau de rayons, ce qui est deja la convention du moteur : ses
+ * gardes `radii === this.shape` et `expression === this.expr` reposent sur la meme
+ * stabilite. Un profil inconnu, ou `null`, ne corrige rien — l'API accepte n'importe quel
+ * tableau et le moteur n'a pas a dependre de la prudence de ses appelants.
+ */
+function batir(): Map<number[], Map<string, { x: number; y: number }>> {
+  return new Map(
+  SHAPES.map((forme) => {
+    const par = new Map<string, { x: number; y: number }>()
+    for (const def of STATES) {
+      if (!def.baseBody) continue
+      const expressions = def.baseFace ? [null, ...EXPRESSIONS] : [null]
+      for (const expr of expressions) {
+        par.set(clef(def.id, expr?.id ?? null), decalagePour(def, forme.radii, expr))
+      }
+    }
+    return [forme.radii, par]
+  })
+  )
+}
+
+const DECALAGES = batir()
+
+/**
+ * Decalage a appliquer aux deux yeux pour cette forme sur cet etat, en unites de rayon
+ * de boule — le moteur le remet a son echelle.
+ *
+ * Vaut zero des que la forme n'est pas au catalogue, ce qui couvre `null` et le cercle :
+ * sur le cercle les deux profils sont le meme, donc la marge est deja celle exigee et la
+ * descente sort au premier tour. La forme relevee sur la video ne bouge donc pas, sans
+ * cas particulier.
+ */
+export function decalageDesYeux(
+  radii: number[] | null,
+  state: StateId,
+  expr: string | null
+): { x: number; y: number } {
+  if (!radii) return NUL
+  const par = DECALAGES.get(radii)
+  if (!par) return NUL
+  // un etat sans visage de repos n'a qu'une entree, quelle que soit l'expression
+  return par.get(clef(state, expr)) ?? par.get(clef(state, null)) ?? NUL
+}
+
+/** Pour les tests : de quoi verifier la table sans refaire la geometrie. */
+/** Pour les tests : de quoi chronometrer la construction de la table. */
+export const POUR_TESTS = { batir }

--- a/src/bot/skins.test.ts
+++ b/src/bot/skins.test.ts
@@ -1,0 +1,325 @@
+import { describe, expect, it } from 'vitest'
+import { BotEngine, type RenderedEye } from './engine'
+import { decalageDesYeux, POUR_TESTS } from './eyefit'
+import { EXPRESSIONS } from './expressions'
+import { DEFAULT_SHAPE, SHAPES, SHAPE_BY_ID } from './skins'
+import { STATES, type StateId } from './states'
+
+/**
+ * Les formes du personnalisateur, mesurees contre le corps qu'elles remplacent.
+ *
+ * Ce fichier verrouille deux choses, et la seconde a coute bien plus que la premiere :
+ *
+ * 1. **La gelule ne sort pas de la silhouette.** Les yeux vivent sur une sphere, et
+ *    `radiusAtAngle` les recolle au contour au prorata du rayon local — ce qui divise leur
+ *    marge par le meme prorata. Une forme etroite dans la direction de l'oeil le poussait
+ *    contre le bord jusqu'a ce que le masque l'ouvre : la gelule apparaissait comme une
+ *    encoche dans le corps.
+ * 2. **La correction ne se voit pas bouger.** Sept versions l'ont calculee dans la boucle
+ *    de rendu et toutes tremblaient. Les tests d'oscillation ci-dessous sont ce qui les a
+ *    disqualifiees, et ils comparent au CERCLE, la forme que la correction ne touche pas.
+ *
+ * Tout porte sur la GEOMETRIE RENDUE et non sur le calcul : on reprend le contour du corps
+ * et celui de chaque gelule tels que le composant les dessine. C'est la seule facon de
+ * verifier ce que l'oeil voit, et ca ne suppose rien de la methode employee.
+ */
+
+const R = 100
+
+/**
+ * Contour du corps, lu sur le `bodyPath`. `closedPath` emet `M x y` puis un `C` par point,
+ * donc les points de la courbe sont la 3e paire de chaque `C`.
+ */
+function contourDuCorps(d: string) {
+  const pts: Array<{ x: number; y: number }> = []
+  for (const seg of d.slice(1).split('C')) {
+    const n = seg.match(/-?\d+\.?\d*/g)?.map(Number) ?? []
+    if (n.length >= 6) pts.push({ x: n[4]!, y: n[5]! })
+    else if (n.length === 2) pts.push({ x: n[0]!, y: n[1]! })
+  }
+  return pts
+}
+
+/** Le point est-il dans le polygone ? Lancer de rayon. */
+function dedans(poly: Array<{ x: number; y: number }>, x: number, y: number) {
+  let on = false
+  for (let i = 0, j = poly.length - 1; i < poly.length; j = i++) {
+    const a = poly[i]!
+    const b = poly[j]!
+    if (a.y > y !== b.y > y && x < ((b.x - a.x) * (y - a.y)) / (b.y - a.y) + a.x) on = !on
+  }
+  return on
+}
+
+/**
+ * Contour d'une gelule en coordonnees ecran : un stade, echantillonne puis passe par la
+ * matrice rendue. Les dimensions sont relues dans le `d` que `capsulePath` a produit
+ * (`M-hw -hh+r A r r ...`), pour ne dependre que de la sortie.
+ *
+ * Trente-deux points suffisent : sur une gelule de 40 unites de long ils sont espaces de
+ * moins de trois unites, la ou le plus petit debordement qu'on ait mesure en vaut trois.
+ */
+function contourDeLOeil(eye: RenderedEye, N = 32) {
+  const g = eye.d.match(/-?\d+\.?\d*/g)!.map(Number)
+  const hw = Math.abs(g[0]!)
+  const r = Math.abs(g[2]!)
+  const droit = Math.abs(g[1]!)
+  const m = eye.matrix.match(/-?\d+\.?\d*/g)!.map(Number)
+  const [a, b, c, d, e, f] = m as [number, number, number, number, number, number]
+  const out: Array<{ x: number; y: number }> = []
+  for (let i = 0; i < N; i++) {
+    const u = (i / N) * 4
+    let x: number
+    let y: number
+    if (u < 1) {
+      const t = Math.PI * (u - 0.5)
+      x = Math.cos(t) * r
+      y = -droit + Math.sin(t) * r
+    } else if (u < 2) {
+      x = hw
+      y = -droit + (u - 1) * 2 * droit
+    } else if (u < 3) {
+      const t = Math.PI * (u - 2 + 0.5)
+      x = Math.cos(t) * r
+      y = droit + Math.sin(t) * r
+    } else {
+      x = -hw
+      y = droit - (u - 3) * 2 * droit
+    }
+    out.push({ x: a * x + c * y + e, y: b * x + d * y + f })
+  }
+  return out
+}
+
+/** Trois secondes a vingt images par seconde : assez pour plusieurs clignements. */
+const INSTANTS = 60
+const PAS = 1 / 20
+
+/**
+ * De combien la gelule la plus debordante sort du corps, en unites de viewBox.
+ *
+ * Balaye le TEMPS et pas seulement la combinaison. La derive du regard deplace l'oeil
+ * d'une douzaine d'unites, donc une seule image ne prouve rien : c'est en ne mesurant qu'a
+ * `POSES[state]` que `capsule` + `effraye` est passe inapercu, alors qu'il sortait de
+ * 4,4 unites une seconde plus tard.
+ */
+function debordement(state: StateId, radii: number[], expr: (typeof EXPRESSIONS)[number] | null) {
+  const e = new BotEngine(R, state, radii, expr)
+  let pire = 0
+  for (let i = 0; i < INSTANTS; i++) {
+    const f = e.sample(i * PAS)
+    const corps = contourDuCorps(f.bodyPath)
+    for (const eye of f.eyes) {
+      for (const p of contourDeLOeil(eye)) {
+        if (dedans(corps, p.x, p.y)) continue
+        pire = Math.max(pire, Math.min(...corps.map((q) => Math.hypot(q.x - p.x, q.y - p.y))))
+      }
+    }
+  }
+  return pire
+}
+
+/** Les etats dont le corps est remplacable par une forme du personnalisateur. */
+const CORPS_DE_BASE = STATES.filter((s) => s.baseBody).map((s) => s.id)
+/** Les autres : leur silhouette EST l'animation, relevee sur la video. */
+const SILHOUETTE_MESUREE = STATES.filter((s) => !s.baseBody).map((s) => s.id)
+
+describe('formes du personnalisateur', () => {
+  // 680 combinaisons x 60 instants x deux contours : le test le plus lourd du depot, et le
+  // seul qui prouve ce que l'oeil voit.
+  it("aucune forme ne laisse un oeil sortir de la silhouette", () => {
+    const fautifs: string[] = []
+    for (const state of CORPS_DE_BASE) {
+      for (const forme of SHAPES) {
+        for (const expr of [null, ...EXPRESSIONS]) {
+          const sortie = debordement(state, forme.radii, expr)
+          if (sortie > 0.05) {
+            fautifs.push(`${state}/${forme.id}/${expr?.id ?? 'pose'} ${sortie.toFixed(1)}`)
+          }
+        }
+      }
+    }
+    // Cinq couples etat x forme debordaient : `wide`+`capsule` de 14,5 unites sur une boule
+    // de rayon 100, `wide`+`triangle` de 11,9, `idle`+`capsule` et `swirl`+`capsule` de 5,3,
+    // `notify`+`goutte` de 3,3.
+    expect(fautifs).toEqual([])
+  }, 30_000)
+
+  /**
+   * Le cercle est la forme relevee sur la video, et le corps par defaut : le choisir dans
+   * le personnalisateur ne doit RIEN changer par rapport a ne rien choisir. C'est ce qui
+   * garantit que la correction est neutre sur la reference — y compris son oeil exterieur,
+   * qui frole deja le bord et doit continuer de le froler. C'est aussi ce qui protege
+   * `public/favicon.svg`, dont les deux matrices d'yeux sont celles de `sample(1)` sur
+   * `idle`, au byte.
+   */
+  it('choisir le cercle rend exactement la meme chose que ne rien choisir', () => {
+    expect(DEFAULT_SHAPE).toBe('cercle')
+    const cercle = SHAPE_BY_ID.get('cercle')!.radii
+    for (const state of CORPS_DE_BASE) {
+      for (const expr of [null, ...EXPRESSIONS]) {
+        const avec = new BotEngine(R, state, cercle, expr).sample(1)
+        const sans = new BotEngine(R, state, null, expr).sample(1)
+        expect(avec.eyes, `${state}/${expr?.id ?? 'pose'}`).toEqual(sans.eyes)
+      }
+      expect(decalageDesYeux(cercle, state, null)).toEqual({ x: 0, y: 0 })
+    }
+  })
+
+  /**
+   * Les silhouettes relevees sur la video ne sont pas remplacables, donc la forme choisie
+   * ne doit pas les atteindre — ni leur corps, ni leurs yeux. `orbit` est le cas qui
+   * compte : la marge de son oeil est plus serree que celle du cercle et elle est pourtant
+   * juste, puisque relevee ainsi. Une regle de marge appliquee sans distinction la
+   * deplacerait.
+   */
+  it("la forme choisie ne touche pas aux etats a silhouette mesuree", () => {
+    for (const state of SILHOUETTE_MESUREE) {
+      const nu = new BotEngine(R, state, null, null).sample(1)
+      for (const forme of SHAPES) {
+        const habille = new BotEngine(R, state, forme.radii, null).sample(1)
+        expect(habille.eyes, `${state}/${forme.id}`).toEqual(nu.eyes)
+        expect(habille.bodyPath).toBe(nu.bodyPath)
+      }
+    }
+  })
+
+  /**
+   * La correction ne doit RIEN modifier a la taille des yeux.
+   *
+   * Une version la mettait a l'echelle en meme temps que la position : ca conservait tous
+   * les rapports du visage et restait stable, mais les yeux devenaient visiblement plus
+   * petits sur un corps plat, et changer d'expression animait alors ce grossissement. Ca se
+   * lisait comme un defaut.
+   */
+  it('la taille des yeux ne depend pas de la forme', () => {
+    const tailles = new Set(
+      SHAPES.map((f) =>
+        new BotEngine(R, 'idle', f.radii, null)
+          .sample(1)
+          .eyes.map((y) => y.d)
+          .join('|')
+      )
+    )
+    expect(tailles.size).toBe(1)
+  })
+
+  /**
+   * Le vrai piege : la correction doit etre INVISIBLE en mouvement.
+   *
+   * Ce qu'on mesure est l'OSCILLATION et non la vitesse. Un morph deplace les yeux vite de
+   * toute facon — les expressions ne regardent pas au meme endroit — et c'est du mouvement
+   * voulu. Trembler, c'est aller et REVENIR. On compte donc les changements de sens image
+   * par image, et on les compare au cercle, que la correction ne touche pas.
+   *
+   * La mesure discrimine tres bien : 0 a 1 aller-retour sur le moteur d'origine, 4 a 14
+   * avec des reculs jusqu'a 26 unites sur les versions qui tremblaient.
+   */
+  it('la correction ne fait pas osciller les yeux', () => {
+    const pas = 1 / 60
+
+    const trajectoire = (bâti: () => BotEngine, duree = BotEngine.SHAPE_MORPH) => {
+      const e = bâti()
+      const out: Array<Array<{ x: number; y: number }>> = []
+      for (let t = 0; t <= duree + pas; t += pas) {
+        out.push(
+          e.sample(t).eyes.map((eye) => {
+            const n = eye.matrix.match(/-?\d+\.?\d*/g)!.map(Number)
+            return { x: n[4]!, y: n[5]! }
+          })
+        )
+      }
+      return out
+    }
+
+    /** Combien de fois un oeil repart en arriere, et de combien au plus. */
+    const allersRetours = (suite: Array<Array<{ x: number; y: number }>>) => {
+      let n = 0
+      let amplitude = 0
+      const yeux = Math.min(...suite.map((f) => f.length))
+      for (let j = 0; j < yeux; j++) {
+        let px = 0
+        let py = 0
+        for (let i = 1; i < suite.length; i++) {
+          const dx = suite[i]![j]!.x - suite[i - 1]![j]!.x
+          const dy = suite[i]![j]!.y - suite[i - 1]![j]!.y
+          const len = Math.hypot(dx, dy)
+          if (len <= 0.05) continue
+          if ((px || py) && dx * px + dy * py < 0) {
+            n++
+            amplitude = Math.max(amplitude, len)
+          }
+          px = dx
+          py = dy
+        }
+      }
+      return { n, amplitude }
+    }
+
+    const cercle = SHAPE_BY_ID.get('cercle')!.radii
+    const morphDeForme = (radii: number[]) =>
+      allersRetours(
+        trajectoire(() => {
+          const e = new BotEngine(R, 'idle', cercle, null)
+          e.setShape(radii, 0)
+          return e
+        })
+      )
+    const auRepos = (radii: number[]) =>
+      allersRetours(trajectoire(() => new BotEngine(R, 'idle', radii, null), 3))
+    const morphsDExpression = (radii: number[]) =>
+      EXPRESSIONS.map((expr) =>
+        allersRetours(
+          trajectoire(() => {
+            const e = new BotEngine(R, 'idle', radii, EXPRESSIONS[0]!)
+            e.setExpression(expr, 0)
+            return e
+          })
+        )
+      ).reduce((a, b) => ({ n: a.n + b.n, amplitude: Math.max(a.amplitude, b.amplitude) }), {
+        n: 0,
+        amplitude: 0
+      })
+
+    /*
+     * Sur le CERCLE, rien du tout : la correction y est nulle, donc elle ne peut ajouter
+     * aucun mouvement, et c'est la reference des trois comparaisons.
+     */
+    expect(morphsDExpression(cercle).n, 'cercle : morphs d expression').toBe(0)
+
+    for (const forme of SHAPES) {
+      // Au repos, la seule chose qui bouge est la derive du regard. Une correction qui la
+      // suivrait ferait trembler les yeux en permanence : c'est le defaut le plus visible
+      // de tous, et le premier qu'on a eu.
+      expect(auRepos(forme.radii).n, `${forme.id} : derive au repos`).toBeLessThanOrEqual(
+        auRepos(cercle).n + 1
+      )
+      // Un changement de forme fait bouger le decalage, mais sur la meme courbe que la
+      // silhouette : aucun aller-retour de plus que le cercle.
+      expect(morphDeForme(forme.radii).n, `morph de forme vers ${forme.id}`).toBeLessThanOrEqual(
+        morphDeForme(cercle).n + 1
+      )
+      /*
+       * Un changement d'expression fait passer le decalage d'une entree de table a l'autre.
+       * Sept formes sur huit n'y gagnent aucun aller-retour ; la `goutte` passe de un
+       * rebroussement de 6,3 unites — deja present sans correction — a deux de 11,1. La
+       * borne laisse passer ca et rien de plus : les versions fautives etaient a 26.
+       */
+      expect(
+        morphsDExpression(forme.radii).amplitude,
+        `${forme.id} : morphs d expression`
+      ).toBeLessThan(14)
+    }
+  })
+
+  /**
+   * La table est une constante de module. Elle doit rester assez rapide a batir pour ne pas
+   * peser sur le premier affichage : c'est le seul cout que ce correctif ajoute au moteur,
+   * qui ne fait plus ensuite qu'y lire deux entrees et les interpoler.
+   */
+  it('la table se batit en quelques millisecondes', () => {
+    const t = performance.now()
+    POUR_TESTS.batir()
+    expect(performance.now() - t).toBeLessThan(200)
+  })
+})


### PR DESCRIPTION
The eyes are placed on a sphere and re-stuck onto the real outline by `radiusAtAngle`. That pro-rata places their **centre** correctly, but the eye has a size, and the margin left in front of the edge gets multiplied by the same factor. A shape that is narrow in the eye's direction therefore pushed it against the edge until the mask opened it outwards — the gélule showed up as a notch cut into the body.

Measured over **680 combinations × 60 instants** (shape × expression × base-body state, sweeping time because the resting gaze drift moves the eye by a dozen units): **5 state × shape pairs let an eye out of the body**, up to 14.5 units on a ball of radius 100. Now **none do**.

### The offset is a table, not a solver — and that is the fix

Seven versions solved the geometry inside the render loop, and every one produced a visible motion artefact: permanent trembling, a 26-unit direction flip when the nearest edge switched, a sudden resize when eye size entered the calculation. Everything such a solver reads moves at 60 fps — gaze drift, pointer, expression mid-morph, which edge is nearest, which eye is tightest. The established names for what went wrong are an *active-set change*, a *non-smooth objective* (`min` is C0 but not C1) and *chattering*.

`src/bot/eyefit.ts` solves it **once at import** instead, yielding one entry per (shape, state, expression). The engine reads the table on the **boundaries** of each morph and interpolates with that morph's own `easeOutQuint` — never on the interpolated value, which has no identity and exists in no table. Same idea as *pose space deformation* (Lewis, Cordner & Fong, SIGGRAPH 2000): a corrective authored per pose, resolved at setup, looked up at runtime. The table is a module constant built from pure data, the same nature as the pre-drawn blink schedule in `face.ts`, so `engine.sample(t)` stays a pure function of time. It costs 20 ms, once.

The correction is a **translation common to both eyes**, hence an isometry: spacing, sizes and tilts are preserved to the pixel.

### Verified

| | before | after |
|---|---|---|
| state × shape pairs with an eye outside the body | 5 | **0** |
| eye size | — | **identical across all 8 shapes** |
| back-and-forths at rest, on a shape morph | 0–1 of 0.05 units | **identical** |
| back-and-forths on an expression morph | 0 on 7 of 8 shapes | **0 on 7 of 8** |
| `cercle` | reference | **untouched, offset exactly `{0,0}`** — which is also what protects `favicon.svg` |

One residual, stated plainly: on the teardrop, an expression change goes from 1 reversal of 6.3 units (already present *without* the fix) to 2 of 11.1. That is the cost of one entry per expression; a single entry per shape left 4 overflows, because on a capsule `neutre` has its eyes high and needs to go down while `effraye` has them low and needs to go up.

`docs/architecture.md` lists the six variants that were measured and rejected, so they don't get re-tried. `src/bot/skins.test.ts` locks the lot — 184 tests pass, `pnpm build` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)