### PR TITLE
Export robustness: silent failures, leaked encoder, no cancel

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -31,6 +31,7 @@ import {
   GIF_IMAGES,
   GIF_PAS,
   BLANC,
+  Abandon,
   couleurDeFond,
   cycleImages,
   cyclePas,
@@ -534,6 +535,17 @@ const formatCycle = ref<FormatCycle>(FORMAT_CYCLE_DEFAUT)
 const fondCycle = ref<FondGif>(FOND_GIF_DEFAUT)
 /** `null` tant qu'on n'encode pas ; sinon la fraction faite, pour la barre. */
 const avancementCycle = ref<number | null>(null)
+/**
+ * Le dernier export de montage a-t-il echoue ?
+ *
+ * Un etat a lui, et non `etatExport` : celui-la pilote `ExportBar`, qui n'est rendue que
+ * dans la vue Personnaliser, alors que cette boite vit dans les Animations. L'echec
+ * partait donc dans un composant absent de l'ecran — la barre de progression disparaissait,
+ * la boite restait ouverte, et rien ne disait pourquoi.
+ */
+const erreurCycle = ref(false)
+/** De quoi abandonner l'encodage en cours. */
+let abandonCycle: AbortController | null = null
 
 /**
  * Exporte le MONTAGE, pas l'avatar : c'est le cycle courant qui est rejoue hors
@@ -542,6 +554,9 @@ const avancementCycle = ref<number | null>(null)
  */
 async function exporteCycle() {
   if (avancementCycle.value !== null) return
+  erreurCycle.value = false
+  const controle = new AbortController()
+  abandonCycle = controle
   const blocs = cycle.value.blocks
   const format = formatCycle.value
   const images = cycleImages(totalDuration(blocs), format)
@@ -555,7 +570,7 @@ async function exporteCycle() {
     const mp4 = format === 'mp4'
     // La video n'a pas d'alpha : elle impose le blanc. Le GIF, lui, garde le choix.
     const fichier = mp4
-      ? await cycleVersMp4(reglages, blocs, taille, images, pas, BLANC, suit)
+      ? await cycleVersMp4(reglages, blocs, taille, images, pas, BLANC, suit, controle.signal)
       : await cycleVersGif(
           reglages,
           blocs,
@@ -563,18 +578,34 @@ async function exporteCycle() {
           images,
           pas,
           couleurDeFond(fondCycle.value),
-          suit
+          suit,
+          controle.signal
         )
     telecharge(fichier, nomFichier(nomDeCycle(cycle.value), '', '', mp4 ? 'mp4' : 'gif'))
     dialogueCycle.value = false
-  } catch {
-    etatExport.value = 'erreur'
-    clearTimeout(confirmation)
-    confirmation = setTimeout(() => (etatExport.value = 'pret'), CONFIRMATION_MS)
+  } catch (e) {
+    // Un abandon n'est pas un echec : on ne signale pas a quelqu'un qu'il a obtenu ce
+    // qu'il demandait.
+    if (!(e instanceof Abandon)) erreurCycle.value = true
   } finally {
     avancementCycle.value = null
+    abandonCycle = null
   }
 }
+
+/** Abandon demande depuis la boite : Echap, ou son bouton. */
+function annuleCycle() {
+  abandonCycle?.abort()
+}
+
+/*
+ * L'echec appartient a la TENTATIVE, pas a la boite : la rouvrir doit la rendre neuve.
+ * Sans ce nettoyage, un echec ancien s'affichait encore a l'ouverture suivante et le
+ * bouton proposait de « reessayer » quelque chose qu'on n'avait pas encore demande.
+ */
+watch(dialogueCycle, (ouverte) => {
+  if (ouverte) erreurCycle.value = false
+})
 
 /** Duree d'affichage de la confirmation d'export. */
 const CONFIRMATION_MS = 1800
@@ -850,7 +881,9 @@ watch(
           v-model:format="formatCycle"
           v-model:fond="fondCycle"
           :avancement="avancementCycle"
+          :erreur="erreurCycle"
           @confirm="exporteCycle"
+          @annuler="annuleCycle"
         />
 
         <!-- Export de l'AVATAR : le GIF est le seul format a demander son fond,

--- a/src/components/CycleDialog.vue
+++ b/src/components/CycleDialog.vue
@@ -18,11 +18,15 @@ import { useModalDialog } from '@/ui/useModalDialog'
  * la video n'a pas de canal alpha du tout, donc il n'y a pas de choix a refuser,
  * il n'y a pas de choix.
  */
-const props = defineProps<{ avancement: number | null }>()
+const props = defineProps<{
+  avancement: number | null
+  /** true = le dernier essai a echoue. La boite le dit et propose de reessayer. */
+  erreur: boolean
+}>()
 const open = defineModel<boolean>('open', { required: true })
 const format = defineModel<FormatCycle>('format', { required: true })
 const fond = defineModel<FondGif>('fond', { required: true })
-const emit = defineEmits<{ confirm: [] }>()
+const emit = defineEmits<{ confirm: []; annuler: [] }>()
 
 const boite = useTemplateRef<HTMLDialogElement>('boite')
 useModalDialog(open, boite)
@@ -37,6 +41,15 @@ useModalDialog(open, boite)
  */
 const formats = FORMATS_CYCLE.filter((f) => f !== 'mp4' || videoPossible())
 
+/*
+ * Le modele est corrige, pas seulement la liste. Le defaut est `mp4`, donc sur un
+ * navigateur sans `VideoEncoder` la boite n'affichait qu'une radio « GIF » et elle etait
+ * DECOCHEE : l'option etait cachee mais la valeur, elle, gagnait, et l'export partait
+ * quand meme sur l'encodeur video pour echouer aussitot. Cacher un choix ne suffit pas, il
+ * faut aussi ne plus le porter.
+ */
+if (!formats.includes(format.value)) format.value = formats[0]!
+
 const occupe = computed(() => props.avancement !== null)
 const pourcent = computed(() => Math.round((props.avancement ?? 0) * 100))
 
@@ -44,6 +57,18 @@ function confirm() {
   // La boite reste ouverte pendant l'encodage : c'est elle qui porte la
   // progression, et un cycle de trente secondes ne s'exporte pas instantanement.
   if (!occupe.value) emit('confirm')
+}
+
+/**
+ * Fermer, c'est ABANDONNER quand l'encodage tourne.
+ *
+ * Sans ca, Echap ou le bouton refermaient la boite pendant que l'export continuait
+ * jusqu'au bout et declenchait le telechargement d'un fichier que plus personne
+ * n'attendait.
+ */
+function ferme() {
+  if (occupe.value) emit('annuler')
+  open.value = false
 }
 </script>
 
@@ -53,7 +78,7 @@ function confirm() {
     class="dialogue m-auto w-80 rounded-2xl bg-white p-5 text-[var(--ink)] shadow-xl"
     :aria-label="t('timeline.export')"
     @close="open = false"
-    @cancel.prevent="open = false"
+    @cancel.prevent="ferme"
   >
     <form class="flex flex-col gap-4" @submit.prevent="confirm">
       <div class="flex flex-col gap-1">
@@ -107,6 +132,13 @@ function confirm() {
       </fieldset>
 
       <!-- la progression remplace les boutons : rien d'autre a faire qu'attendre -->
+      <!-- l'echec s'affiche ICI et pas dans la barre d'export : celle-la n'est rendue
+           que dans la vue Personnaliser, alors que cette boite vit dans les Animations,
+           donc le message partait dans un composant absent de l'ecran -->
+      <p v-if="erreur && !occupe" class="text-xs text-[var(--danger)]" role="alert">
+        {{ t('export.failed') }}
+      </p>
+
       <div v-if="occupe" class="flex flex-col gap-1.5">
         <!--
           Pas de `transition` sur la largeur : une transition sur `width` passe par
@@ -117,16 +149,25 @@ function confirm() {
         <div class="h-1.5 overflow-hidden rounded-full bg-black/10">
           <div class="h-full rounded-full bg-[var(--ink)]" :style="{ width: `${pourcent}%` }" />
         </div>
-        <p class="text-xs tabular-nums text-[var(--muted)]">
-          {{ t('export.cycleProgress') }} {{ pourcent }} %
-        </p>
+        <div class="flex items-center justify-between gap-2">
+          <p class="text-xs tabular-nums text-[var(--muted)]">
+            {{ t('export.cycleProgress') }} {{ pourcent }} %
+          </p>
+          <button
+            type="button"
+            class="h-7 cursor-pointer rounded-lg px-2 text-xs text-[var(--muted)] transition hover:bg-black/5 hover:text-[var(--ink)]"
+            @click="ferme"
+          >
+            {{ t('dialog.cancel') }}
+          </button>
+        </div>
       </div>
 
       <div v-else class="flex justify-end gap-2">
         <button
           type="button"
           class="h-8 cursor-pointer rounded-lg px-3 text-xs text-[var(--muted)] transition hover:bg-black/5 hover:text-[var(--ink)]"
-          @click="open = false"
+          @click="ferme"
         >
           {{ t('dialog.cancel') }}
         </button>
@@ -134,7 +175,7 @@ function confirm() {
           type="submit"
           class="h-8 cursor-pointer rounded-lg bg-[var(--ink)] px-3 text-xs text-[var(--paper)] transition hover:opacity-90 active:scale-95"
         >
-          {{ t('export.gifConfirm') }}
+          {{ erreur ? t('export.cycleReessayer') : t('export.gifConfirm') }}
         </button>
       </div>
     </form>

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -44,6 +44,7 @@ const en: typeof fr = {
     cycle_gif: 'Animated GIF',
     cycle_gif_aide: 'Plays anywhere, heavier',
     cycleProgress: 'Exporting…',
+    cycleReessayer: 'Try again',
     gifTitle: 'Download animated GIF',
     gifDetail:
       'GIF transparency is all-or-nothing: with no background, the ball\u2019s edge comes out a little hard.',

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -67,6 +67,7 @@ export default {
     cycle_gif: 'GIF animé',
     cycle_gif_aide: 'Lu partout, plus lourd',
     cycleProgress: 'Export en cours…',
+    cycleReessayer: 'Réessayer',
     gifTitle: 'Télécharger le GIF animé',
     gifDetail:
       "Le GIF ne gère la transparence qu'en tout ou rien : sans fond, le contour de la boule est un peu dur.",

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -49,6 +49,7 @@ const zh: typeof fr = {
     cycle_gif: 'GIF 动图',
     cycle_gif_aide: '到处可播，体积更大',
     cycleProgress: '正在导出…',
+    cycleReessayer: '重试',
     gifTitle: '下载 GIF 动图',
     gifDetail: 'GIF 的透明只有全有或全无：不加背景时，球体边缘会略显生硬。',
     gifBackground: '背景',

--- a/src/ui/capture.ts
+++ b/src/ui/capture.ts
@@ -14,7 +14,7 @@ import { createApp, h, nextTick, ref } from 'vue'
 import BloubBot from '@/components/BloubBot.vue'
 import type { Block } from '@/bot/cycles'
 import { gifAnime, gifIndexe, indexe, nouvellePalette, recense, svgAnime } from './anime'
-import { DEMI_ECRAN, sansCommentaires, viewBoxExport } from './export'
+import { arrete, DEMI_ECRAN, sansCommentaires, viewBoxExport } from './export'
 
 /**
  * Serialise le SVG affiche en un document autonome, recadre sur la boule.
@@ -150,7 +150,8 @@ export async function cycleVersMp4(
   images: number,
   pas: number,
   fond: string,
-  avance?: Avancement
+  avance?: Avancement,
+  signal?: AbortSignal
 ): Promise<Blob> {
   const { versMp4 } = await import('./video')
   const canvas = document.createElement('canvas')
@@ -164,7 +165,8 @@ export async function cycleVersMp4(
         const svg = await lecteur.rendre(i * pas)
         await dessine(svgAutonome(svg, taille, viewBoxExport(DEMI_ECRAN)), taille, canvas, fond)
       },
-      avance
+      avance,
+      signal
     )
   } finally {
     lecteur.ferme()
@@ -197,7 +199,8 @@ export async function cycleVersGif(
   images: number,
   pas: number,
   fond: string | null,
-  avance?: Avancement
+  avance?: Avancement,
+  signal?: AbortSignal
 ): Promise<Blob> {
   // Un seul canvas pour les deux passes : il est reinitialise a chaque image.
   const canvas = document.createElement('canvas')
@@ -208,6 +211,9 @@ export async function cycleVersGif(
     const lecteur = await ouvreCycle(reglages, blocs, taille, fond ?? undefined)
     try {
       for (let i = 0; i < images; i++) {
+        // teste a chaque image : un cycle de trente secondes fait deux fois six cents
+        // images, et l'abandon ne doit pas attendre la fin d'une passe
+        arrete(signal)
         const svg = await lecteur.rendre(i * pas)
         const ctx = await dessine(svgAutonome(svg, taille, vue), taille, canvas, fond)
         lis(i, ctx.getImageData(0, 0, taille, taille).data)

--- a/src/ui/export.ts
+++ b/src/ui/export.ts
@@ -283,3 +283,29 @@ export function nomFichier(
 export function videoPossible() {
   return typeof VideoEncoder !== 'undefined'
 }
+
+/* ------------------------------------------------------------- abandon d'export */
+
+/**
+ * Erreur d'un export abandonne par l'utilisateur.
+ *
+ * Une classe et non un booleen de retour : l'abandon doit remonter toute la pile
+ * d'encodage, dont les `finally` liberent au passage l'encodeur video et le lecteur hors
+ * ecran. L'appelant la reconnait pour ne PAS afficher d'erreur — on ne signale pas a
+ * quelqu'un qu'il a obtenu ce qu'il demandait.
+ *
+ * Elle vit ICI et pas dans `video.ts` pour la meme raison que `videoPossible` juste au
+ * dessus : `capture.ts` en a besoin en import statique, et un import statique de
+ * `video.ts` ramene mediabunny dans le chunk d'entree.
+ */
+export class Abandon extends Error {
+  constructor() {
+    super('export abandonne')
+    this.name = 'Abandon'
+  }
+}
+
+/** Jette si l'utilisateur a demande l'abandon. */
+export function arrete(signal: AbortSignal | undefined) {
+  if (signal?.aborted) throw new Abandon()
+}

--- a/src/ui/video.ts
+++ b/src/ui/video.ts
@@ -16,6 +16,8 @@
  * un fond, la ou le GIF laisse le choix.
  */
 
+import { arrete } from './export'
+
 /**
  * QUANTISEUR explicite, et pas un niveau `QUALITY_*`.
  *
@@ -52,7 +54,9 @@ export async function versMp4(
   images: number,
   fps: number,
   rend: (index: number) => void | Promise<void>,
-  avance?: (fait: number, total: number) => void
+  avance?: (fait: number, total: number) => void,
+  /** Abandon demande par l'utilisateur. Cf. `arrete` ci-dessous. */
+  signal?: AbortSignal
 ): Promise<Blob> {
   const { BufferTarget, CanvasSource, Mp4OutputFormat, Output, Quality } = await import(
     'mediabunny'
@@ -66,17 +70,33 @@ export async function versMp4(
   sortie.addVideoTrack(source, { frameRate: fps })
   await sortie.start()
 
-  const duree = 1 / fps
-  for (let i = 0; i < images; i++) {
-    await rend(i)
-    // `await` sur chaque image et non en lot : c'est ce qui applique la
-    // contre-pression de l'encodeur, donc ce qui borne la memoire.
-    await source.add(i * duree, duree)
-    avance?.(i + 1, images)
-  }
+  /*
+   * A partir d'ici l'encodeur est OUVERT, donc tout chemin de sortie doit passer par
+   * `cancel`. Sans ca, une image qui echoue a se rendre laissait le `VideoEncoder`
+   * derriere elle : Chrome plafonne le nombre d'encodeurs materiels simultanes, si bien
+   * qu'apres quelques echecs les exports suivants tombaient a `start()` pour une raison
+   * qui n'avait plus rien a voir avec la cause reelle. Le lecteur hors ecran de
+   * `capture.ts` est ferme dans un `finally` pour la meme raison ; l'encodeur n'avait pas
+   * son equivalent.
+   */
+  try {
+    const duree = 1 / fps
+    for (let i = 0; i < images; i++) {
+      arrete(signal)
+      await rend(i)
+      // `await` sur chaque image et non en lot : c'est ce qui applique la
+      // contre-pression de l'encodeur, donc ce qui borne la memoire.
+      await source.add(i * duree, duree)
+      avance?.(i + 1, images)
+    }
+    arrete(signal)
 
-  await sortie.finalize()
-  const buffer = sortie.target.buffer
-  if (!buffer) throw new Error('encodage mp4 vide')
-  return new Blob([buffer], { type: 'video/mp4' })
+    await sortie.finalize()
+    const buffer = sortie.target.buffer
+    if (!buffer) throw new Error('encodage mp4 vide')
+    return new Blob([buffer], { type: 'video/mp4' })
+  } catch (e) {
+    await sortie.cancel()
+    throw e
+  }
 }


### PR DESCRIPTION
Four defects in the montage export path, each independent.

**1. MP4 stayed selected where it cannot work.** `CycleDialog` hid the MP4 radio when the browser has no `VideoEncoder`, but the model kept its `mp4` default: the box showed a single, **unchecked** GIF radio and the export went to the video encoder anyway. Hiding a choice is not enough — you also have to stop holding it. Verified: without `VideoEncoder`, radios shown `[gif]` and **checked `[gif]`**.

**2. A failed montage export said nothing.** The failure was written to `etatExport`, which drives `ExportBar` — rendered only in the Customise view, while this dialog lives in Animations. So the progress bar vanished, the box stayed open, and the message went to a component that was not on screen. There is now an error state of its own, shown in the box that already carries the progress, with a *Try again* button. Verified by breaking `getContext`: box open, `role="alert"` = "Échec de l'export", button becomes "Réessayer".

**3. `versMp4` never released the encoder on failure.** No `try`, so a frame that failed to render left the `VideoEncoder` behind. Chrome caps simultaneous hardware encoders, so after a few failures later exports died at `start()` for a reason unrelated to the actual cause. Now every exit path goes through `sortie.cancel()` — the same discipline `capture.ts` already applies to the off-screen player.

**4. No way to cancel.** Escape closed the box while the export ran to completion and downloaded a file nobody was waiting for. An `AbortSignal` now threads through `cycleVersMp4`/`cycleVersGif`, checked once per frame (a 30 s cycle is two passes of six hundred frames, so cancelling must not wait for a pass to end). A cancel is **not** reported as an error — you don't tell someone they got what they asked for. Verified: "Export en cours… 3 %" + Cancel → box closed, 0 alerts.

`Abandon` and `arrete` live in `export.ts`, not `video.ts`: `capture.ts` needs them statically, and any static import of `video.ts` drags mediabunny back into the entry chunk — the trap `videoPossible` already documents. Checked: `video-*.js` stays at 0.77 kB.

`pnpm build` and `pnpm test` (184 tests) pass, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)