### PR TITLE
Guard and bound localStorage

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -43,7 +43,7 @@ import {
 } from '@/ui/export'
 import { HUMEURS } from '@/ui/gaze'
 import { INTRO, INTRO_GAZE, POSE_AT, introDue } from '@/ui/intro'
-import { cle } from '@/ui/stockage'
+import { ecris, lis, type NomStocke } from '@/ui/stockage'
 import {
   blockAt,
   blocksWith,
@@ -121,7 +121,7 @@ const intro = ref(
  * remplit la liste, ensuite les montages de l'utilisateur font foi — y compris
  * ses modifications de celui-la.
  */
-const restored = parseCycles(localStorage.getItem(cle('cycles')))
+const restored = parseCycles(lis('cycles'))
 const cycles = ref<Cycle[]>(restored.length ? restored : [defaultCycle()])
 
 /**
@@ -143,13 +143,13 @@ function locate(id: StateId) {
  * de l'utilisateur, pas un reglage de session. On valide au chargement, un id
  * inconnu retombe sur le defaut.
  */
-function stored(key: string, fallback: string, exists: (v: string) => boolean) {
-  const v = localStorage.getItem(key)
+function stored(nom: NomStocke, fallback: string, exists: (v: string) => boolean) {
+  const v = lis(nom)
   return v && exists(v) ? v : fallback
 }
 
 const activeId = ref(
-  stored(cle('cycle'), cycles.value[0]!.id, (v) => cycles.value.some((c) => c.id === v))
+  stored('cycle', cycles.value[0]!.id, (v) => cycles.value.some((c) => c.id === v))
 )
 const block = ref(0)
 const elapsed = ref(0)
@@ -184,13 +184,25 @@ const state = ref<StateId>(
  * pendant un glisser bloquerait le rendu pour rien.
  */
 let pending: ReturnType<typeof setTimeout>
-watch(cycles, (list) => {
+function enregistreCycles() {
   clearTimeout(pending)
-  pending = setTimeout(() => {
-    localStorage.setItem(cle('cycles'), JSON.stringify(list))
-  }, 250)
+  ecris('cycles', JSON.stringify(cycles.value))
+}
+watch(cycles, () => {
+  clearTimeout(pending)
+  pending = setTimeout(enregistreCycles, 250)
 })
-watch(activeId, (v) => localStorage.setItem(cle('cycle'), v))
+watch(activeId, (v) => ecris('cycle', v))
+
+/*
+ * Le differe se vide a la fermeture, sinon la derniere modification est perdue quand
+ * l'onglet part dans les 250 ms — etirer une carte puis fermer, et le geste n'a pas eu
+ * lieu.
+ *
+ * `pagehide` et pas `beforeunload` : c'est le seul des deux qui se declenche aussi quand
+ * la page passe en cache de navigation sur mobile, ou l'onglet n'est jamais « decharge ».
+ */
+window.addEventListener('pagehide', enregistreCycles)
 
 /* -------------------------------------------------------------------- vues */
 
@@ -405,15 +417,15 @@ const droite = computed(() => !nue.value && view.value !== 'reglages')
 
 /* ------------------------------------------------------------------- skins */
 
-const shape = ref(stored(cle('forme'), DEFAULT_SHAPE, (v) => SHAPE_BY_ID.has(v)))
-const color = ref(stored(cle('couleur'), DEFAULT_COLOR, (v) => COLOR_BY_ID.has(v)))
+const shape = ref(stored('forme', DEFAULT_SHAPE, (v) => SHAPE_BY_ID.has(v)))
+const color = ref(stored('couleur', DEFAULT_COLOR, (v) => COLOR_BY_ID.has(v)))
 const expression = ref(
-  stored(cle('expression'), DEFAULT_EXPRESSION, (v) => EXPRESSION_BY_ID.has(v))
+  stored('expression', DEFAULT_EXPRESSION, (v) => EXPRESSION_BY_ID.has(v))
 )
 
-watch(shape, (v) => localStorage.setItem(cle('forme'), v))
-watch(color, (v) => localStorage.setItem(cle('couleur'), v))
-watch(expression, (v) => localStorage.setItem(cle('expression'), v))
+watch(shape, (v) => ecris('forme', v))
+watch(color, (v) => ecris('couleur', v))
+watch(expression, (v) => ecris('expression', v))
 
 /**
  * Nom du produit, en capitales pour le grand mot du pied de page. PAS traduit —

--- a/src/bot/cycles.test.ts
+++ b/src/bot/cycles.test.ts
@@ -1,17 +1,21 @@
 import { describe, expect, it } from 'vitest'
 import {
+  MAX_BLOCK,
+  MAX_BLOCS,
+  MAX_CYCLES,
+  MIN_BLOCK,
   blockAt,
+  blocksWith,
   clampDuration,
   defaultCycle,
-  MAX_BLOCK,
-  MIN_BLOCK,
+  makeBlock,
   minDurationOf,
   moveBlock,
   nextCycleId,
   parseCycles,
   totalDuration,
-  uniqueName,
-  type Cycle
+  type Cycle,
+  uniqueName
 } from './cycles'
 import { SEQUENCE, STATE_BY_ID } from './states'
 
@@ -154,5 +158,52 @@ describe('relecture du stockage', () => {
     const cycle = parseCycles(raw)[0]!
     expect(Object.keys(cycle).sort()).toEqual(['blocks', 'id', 'name'])
     expect(Object.keys(cycle.blocks[0]!).sort()).toEqual(['duration', 'state'])
+  })
+
+  /*
+   * Le stockage est modifiable et tient quelques megaoctets, alors que rien en aval n'est
+   * dimensionne pour ca. Un seul cycle de 150 000 blocs — environ 4 Mo de JSON, donc dans
+   * le budget — donnait 1 500 000 s de duree, autant de graduations a allouer et une piste
+   * de 29 700 000 px : l'onglet figeait en entrant dans la vue Animations.
+   */
+  it('borne la taille d un montage relu', () => {
+    const blocs = Array.from({ length: 5000 }, () => ({ state: 'idle', duration: 10 }))
+    const raw = JSON.stringify([{ id: 'c1', name: 'A', blocks: blocs }])
+    expect(parseCycles(raw)[0]!.blocks).toHaveLength(MAX_BLOCS)
+  })
+
+  it('borne aussi l ajout depuis l editeur, pas seulement la relecture', () => {
+    let blocs = Array.from({ length: MAX_BLOCS }, () => makeBlock('idle'))
+    expect(blocksWith(blocs, 'egg')).toHaveLength(MAX_BLOCS)
+    // et il reste possible d'ajouter juste en dessous de la borne
+    blocs = blocs.slice(0, MAX_BLOCS - 1)
+    expect(blocksWith(blocs, 'egg')).toHaveLength(MAX_BLOCS)
+  })
+
+  it('borne le nombre de montages relus', () => {
+    const raw = JSON.stringify(
+      Array.from({ length: 500 }, (_, i) => ({
+        id: `c${i}`,
+        name: `A${i}`,
+        blocks: [{ state: 'idle', duration: 2 }]
+      }))
+    )
+    expect(parseCycles(raw)).toHaveLength(MAX_CYCLES)
+  })
+
+  /*
+   * `swirl` est la transition d'entree des reglages, deliberement hors de `SEQUENCE` : un
+   * test la garde hors de la palette et de la planche. Un montage utilisateur ne se
+   * construit qu'a partir de la palette, donc elle ne peut arriver ici que par un stockage
+   * bricole a la main — et on l'y refuse comme partout ailleurs.
+   */
+  it('refuse un etat hors catalogue, `swirl` compris', () => {
+    const raw = '[{"id":"c1","name":"A","blocks":[{"state":"swirl","duration":2},' +
+      '{"state":"idle","duration":2}]}]'
+    expect(parseCycles(raw)[0]!.blocks.map((b) => b.state)).toEqual(['idle'])
+    // un montage qui n'en contiendrait QUE devient vide, donc tombe
+    expect(parseCycles('[{"id":"c1","name":"A","blocks":[{"state":"swirl","duration":2}]}]')).toEqual(
+      []
+    )
   })
 })

--- a/src/bot/cycles.ts
+++ b/src/bot/cycles.ts
@@ -36,6 +36,20 @@ export const MIN_BLOCK = 0.6
  */
 export const MAX_BLOCK = 10
 
+/**
+ * Combien de blocs et de montages on accepte, a l'edition comme a la relecture.
+ *
+ * Ce ne sont pas des limites de produit mais des bornes contre un stockage hostile, qui
+ * est modifiable et tient quelques megaoctets alors que rien en aval n'est dimensionne
+ * pour ca : un seul cycle de 150 000 blocs, soit environ 4 Mo de JSON, donne 1 500 000 s
+ * de duree, autant de graduations a allouer et une piste de 29 700 000 px de large.
+ * L'onglet figeait en entrant dans la vue Animations.
+ *
+ * 200 blocs font une demi-heure de montage, largement au-dela de tout usage.
+ */
+export const MAX_BLOCS = 200
+export const MAX_CYCLES = 50
+
 /** Pas de la molette et du redimensionnement, en secondes. */
 export const STEP = 0.1
 
@@ -109,8 +123,16 @@ export function blockAt(blocks: Block[], t: number): { index: number; elapsed: n
   return { index: blocks.length - 1, elapsed: 0 }
 }
 
-/** Ajoute une animation a la fin du montage (palette de droite ou carte « + »). */
+/**
+ * Ajoute une animation a la fin du montage (palette de droite ou carte « + »).
+ *
+ * Plafonnee a `MAX_BLOCS`, comme la relecture. Sans ca l'editeur laissait construire un
+ * montage plus grand que ce que le stockage rend au rechargement, et le travail
+ * disparaissait en silence — une borne de relecture qui n'est pas aussi une borne d'edition
+ * est un piege, pas une protection.
+ */
 export function blocksWith(blocks: Block[], state: StateId): Block[] {
+  if (blocks.length >= MAX_BLOCS) return blocks
   return [...blocks, makeBlock(state)]
 }
 
@@ -145,8 +167,15 @@ export function nextCycleId(cycles: Cycle[]): string {
 function parseBlock(raw: unknown): Block | null {
   if (typeof raw !== 'object' || raw === null) return null
   const { state, duration } = raw as { state?: unknown; duration?: unknown }
-  // un etat inconnu vient d'une version anterieure ou d'un stockage bricole
-  if (typeof state !== 'string' || !STATE_BY_ID.has(state as StateId)) return null
+  /*
+   * Valide contre SEQUENCE et non contre `STATE_BY_ID` : ce dernier contient `swirl`, qui
+   * est deliberement hors du catalogue — c'est la transition d'entree des reglages, un
+   * test la verrouille hors de la palette et de la planche. Un montage utilisateur ne se
+   * construit qu'a partir de la palette, donc un `swirl` ne peut y arriver que par un
+   * stockage bricole a la main, et il n'y a aucune raison de l'y tolerer quand on l'exclut
+   * partout ailleurs.
+   */
+  if (typeof state !== 'string' || !SEQUENCE.includes(state as StateId)) return null
   if (typeof duration !== 'number' || !Number.isFinite(duration)) return null
   return { state: state as StateId, duration: clampDuration(state as StateId, duration) }
 }
@@ -158,7 +187,12 @@ function parseCycle(raw: unknown, seen: Cycle[]): Cycle | null {
   // le nom peut etre vide — c'est le montage d'amorce, qui suit la langue
   if (typeof name !== 'string') return null
   if (!Array.isArray(blocks)) return null
-  const kept = blocks.map(parseBlock).filter((b): b is Block => b !== null)
+  // on tronque AVANT de relire : valider 150 000 blocs pour n'en garder que 200 serait
+  // faire le travail qu'on cherche justement a eviter
+  const kept = blocks
+    .slice(0, MAX_BLOCS)
+    .map(parseBlock)
+    .filter((b): b is Block => b !== null)
   if (!kept.length) return null
   if (seen.some((c) => c.id === id)) return null
   return { id, name, blocks: kept }
@@ -179,7 +213,7 @@ export function parseCycles(raw: string | null): Cycle[] {
   }
   if (!Array.isArray(data)) return []
   const out: Cycle[] = []
-  for (const item of data) {
+  for (const item of data.slice(0, MAX_CYCLES)) {
     const cycle = parseCycle(item, out)
     if (cycle) out.push(cycle)
   }

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,5 +1,5 @@
 import { computed, ref, watchEffect } from 'vue'
-import { cle } from '@/ui/stockage'
+import { ecris, lis } from '@/ui/stockage'
 import { formePlurielle, interpoler } from './format'
 import { choisirLangue, estLangue, type Langue, tagDe } from './langues'
 import fr from './locales/fr'
@@ -25,10 +25,8 @@ type Chemins<T, P extends string = ''> = {
 
 export type Cle = Chemins<typeof fr>
 
-const CLE_STOCKAGE = cle('langue')
-
 const courante = ref<Langue>(
-  choisirLangue(localStorage.getItem(CLE_STOCKAGE), navigator.languages ?? [navigator.language])
+  choisirLangue(lis('langue'), navigator.languages ?? [navigator.language])
 )
 
 /**
@@ -44,7 +42,7 @@ export const langue = computed<Langue>({
   set: (valeur) => {
     if (!estLangue(valeur)) return
     courante.value = valeur
-    localStorage.setItem(CLE_STOCKAGE, valeur)
+    ecris('langue', valeur)
   }
 })
 

--- a/src/ui/stockage.test.ts
+++ b/src/ui/stockage.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cle, ecris, lis } from './stockage'
+
+/**
+ * La garde du stockage.
+ *
+ * Ce qui est verrouille ici n'est pas la persistance, c'est le fait que l'application
+ * DEMARRE quand le stockage est interdit. Tout ce qu'elle relit l'est a l'evaluation des
+ * modules, et toucher `localStorage` peut lever un `SecurityError` — Chrome regle sur
+ * « bloquer tous les cookies », iframe tierce, politique d'entreprise. L'exception
+ * remontait le `setup` de `App.vue` et la page restait blanche : aucun bot, pour un
+ * reglage de navigateur qui n'a rien a voir avec le fait de regarder une animation.
+ */
+
+/** Un `localStorage` qui refuse tout, comme quand l'acces est bloque. */
+function interdit() {
+  const jette = () => {
+    throw new DOMException('acces refuse', 'SecurityError')
+  }
+  vi.stubGlobal('localStorage', {
+    get length(): number {
+      return jette()
+    },
+    getItem: jette,
+    setItem: jette,
+    removeItem: jette,
+    clear: jette,
+    key: jette
+  })
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('garde du stockage', () => {
+  it('prefixe les cles avec le nom du produit', () => {
+    expect(cle('cycles')).toBe('bloub:cycles')
+  })
+
+  it('rend `null` au lieu de jeter quand la lecture est refusee', () => {
+    interdit()
+    expect(() => lis('cycles')).not.toThrow()
+    expect(lis('cycles')).toBeNull()
+  })
+
+  it('ne jette pas quand l ecriture est refusee', () => {
+    interdit()
+    expect(() => ecris('cycles', '[]')).not.toThrow()
+  })
+
+  /**
+   * Le quota est l'autre facon d'echouer, et elle arrive sur un stockage AUTORISE. Celle-la
+   * partait d'un `setTimeout`, donc en rejet non traite : la persistance s'arretait sans
+   * que rien ne le dise.
+   */
+  it('ne jette pas quand le quota est depasse', () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => null,
+      setItem: () => {
+        throw new DOMException('plein', 'QuotaExceededError')
+      }
+    })
+    expect(() => ecris('cycles', '[]')).not.toThrow()
+  })
+
+  it('lit et ecrit vraiment quand le stockage repond', () => {
+    const tas = new Map<string, string>()
+    vi.stubGlobal('localStorage', {
+      getItem: (k: string) => tas.get(k) ?? null,
+      setItem: (k: string, v: string) => void tas.set(k, v)
+    })
+    ecris('forme', 'goutte')
+    expect(tas.get('bloub:forme')).toBe('goutte')
+    expect(lis('forme')).toBe('goutte')
+    expect(lis('couleur')).toBeNull()
+  })
+})

--- a/src/ui/stockage.ts
+++ b/src/ui/stockage.ts
@@ -19,3 +19,39 @@ export type NomStocke = (typeof NOMS)[number]
 export function cle(nom: NomStocke): string {
   return `${PREFIXE}${nom}`
 }
+
+/**
+ * Lecture GARDEE du stockage.
+ *
+ * Toucher `localStorage` peut jeter, et pas seulement echouer : quand l'acces est refuse
+ * — Chrome regle sur « bloquer tous les cookies », iframe tierce, politique d'entreprise —
+ * la simple lecture de la propriete leve un `SecurityError`. Or tout ce que l'application
+ * relit l'est a l'evaluation des modules, donc l'exception remontait le `setup` de
+ * `App.vue` et la page restait BLANCHE : pas de bot du tout, pour un reglage de navigateur
+ * qui n'a rien a voir avec le fait de regarder une animation.
+ *
+ * On perd la persistance, jamais l'application. C'est le seul arbitrage possible ici : il
+ * n'y a rien a sauver de force, uniquement un avatar a retrouver si on peut.
+ */
+export function lis(nom: NomStocke): string | null {
+  try {
+    return localStorage.getItem(cle(nom))
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Ecriture GARDEE du stockage.
+ *
+ * Meme raison qu'en lecture, plus le quota : un `setItem` peut lever
+ * `QuotaExceededError`. Celle du cycle partait d'un `setTimeout`, donc en rejet non
+ * traite — la persistance s'arretait sans que rien ne le dise.
+ */
+export function ecris(nom: NomStocke, valeur: string) {
+  try {
+    localStorage.setItem(cle(nom), valeur)
+  } catch {
+    // stockage refuse ou plein : on continue sans persister
+  }
+}

--- a/src/ui/timeline.test.ts
+++ b/src/ui/timeline.test.ts
@@ -55,6 +55,21 @@ describe('graduation de la regle', () => {
   it('ne rend pas la piste vide sur un montage minuscule', () => {
     expect(ticksFor(0.6, BASE_SCALE).length).toBeGreaterThan(0)
   })
+
+  /*
+   * Garde-fou independant de celui de `parseCycles` : cette fonction rend un objet par
+   * graduation et le composant un `<span>` par objet, donc une duree aberrante se paie en
+   * centaines de milliers de noeuds. Elle ne doit pas dependre d'un garde situe ailleurs.
+   */
+  it('ne rend jamais un nombre aberrant de graduations', () => {
+    for (const total of [1e5, 1e7, 1.5e6]) {
+      const ticks = ticksFor(total, BASE_SCALE)
+      expect(ticks.length, `total=${total}`).toBeLessThanOrEqual(2000)
+      // et elles restent croissantes et bien formees
+      expect(ticks[0]!.t).toBe(0)
+      expect(ticks.every((x, i) => i === 0 || x.t > ticks[i - 1]!.t)).toBe(true)
+    }
+  })
 })
 
 describe('bornes de la loupe', () => {

--- a/src/ui/timeline.ts
+++ b/src/ui/timeline.ts
@@ -55,9 +55,23 @@ export function ticksFor(total: number, scale: number): Array<{ t: number; major
   const major = STEPS.find((s) => s * scale >= TICK_SPACING) ?? STEPS[STEPS.length - 1]!
   const step = (major / 5) * scale >= 7 ? major / 5 : major
   const out: Array<{ t: number; major: boolean }> = []
-  for (let i = 0; i * step <= total + 1e-6; i++) {
+  for (let i = 0; i * step <= total + 1e-6 && out.length < MAX_TICKS; i++) {
     const t = i * step
     out.push({ t, major: Math.abs(t / major - Math.round(t / major)) < 1e-6 })
   }
   return out
 }
+
+/**
+ * Plafond du nombre de graduations. Garde-fou et non reglage.
+ *
+ * `parseCycles` borne deja la taille d'un montage relu, mais cette fonction ne doit pas
+ * dependre de ce garde-la pour rester bornee : elle rend un objet par graduation et le
+ * composant un `<span>` par objet, donc une duree aberrante — un montage bricole a la
+ * main, un zoom extreme — se paie en centaines de milliers de noeuds et l'onglet fige.
+ *
+ * Deux mille couvre trente minutes de montage au zoom le plus fin, soit bien plus que ce
+ * que `MAX_BLOCS` autorise a relire. La regle est de toute facon plus large que l'ecran :
+ * la piste defile, elle n'affiche jamais tout.
+ */
+const MAX_TICKS = 2000


### PR DESCRIPTION
Two independent failure modes around persisted state, plus two follow-ups from the same task.

**1. A forbidden `localStorage` made the page blank.** Everything the app reads back is read at module evaluation, and *touching* `localStorage` can throw, not merely fail: when access is denied — Chrome set to "block all cookies", third-party iframe, enterprise policy — reading the property raises a `SecurityError`. That propagated out of `App.vue`'s `setup` and the page stayed blank: no bot at all, for a browser setting unrelated to watching an animation. Writes could also throw `QuotaExceededError`, and the cycle write came from a `setTimeout`, so it was an unhandled rejection that silently stopped all persistence.

`stockage.ts` — which held nothing but key names — now owns `lis`/`ecris`, and the eight call sites go through them. **No unguarded access to `localStorage` remains anywhere in `src/`.** We lose persistence, never the application.

**2. A hostile montage in storage froze the tab.** `parseCycles` validated shape thoroughly but never size. One cycle of 150 000 blocks — about 4.65 MB of JSON, comfortably inside the storage budget — gave 1 500 000 s of duration, as many tick objects to allocate, a `<span>` each, and a track 29 700 000 px wide. Bounds now: `MAX_BLOCS = 200` (half an hour of montage) and `MAX_CYCLES = 50`, applied *before* parsing, and `ticksFor` caps its own output independently at 2000 so it doesn't rely on a guard living elsewhere. Measured: the 4.65 MB payload reads back as 200 blocks in 79 ms; `ticksFor` returns 2000 for both 1.5 M and 10 M seconds.

The same bound now applies to **editing**: `blocksWith` refuses past `MAX_BLOCS`. A read bound that isn't also an edit bound is a trap, not a protection — the editor would let you build past it and a reload would silently drop the work.

**3. `swirl` could enter through storage.** The task left this one open. Decided: validate against `SEQUENCE`, not `STATE_BY_ID`. `swirl` is the settings-view entry transition, deliberately outside the catalogue and locked out of the palette and the board by a test; a user's montage is only ever built from the palette, so it can only arrive by hand-edited storage, and there's no reason to tolerate it where it's excluded everywhere else.

**4. The 250 ms debounce lost the last change** if the tab went away inside the window. Flushed on `pagehide` — not `beforeunload`, since only `pagehide` also fires when a mobile page enters the back/forward cache.

New `src/ui/stockage.test.ts` stubs a throwing `localStorage` and locks that startup survives it. `pnpm build` and `pnpm test` (194 tests) pass, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)