### PR TITLE
Shared render frame, dead code, derived block floor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,10 @@ Details and the reasoning behind each are in [docs/](docs/):
   a radial profile, or `profileFromPolygon`.
 - **The eyes are holes in a `<mask>`**, not white shapes on top. That's what makes
   them clip against the silhouette on their own.
+- **The render frame lives in `src/bot/repere.ts`**: `RAYON` (100) and `DEMI_VIEWBOX`
+  (158) define what `sample()` returns, so they can't sit in a `<script setup>` where
+  nothing can import them — `export.ts` used to redeclare one by hand. The Vue component
+  is a client of the engine, not its definition.
 - **Anything sitting "on" the body must follow its real radius**: `radiusAtAngle`
   (defined in `shape.ts`, applied by `engine.ts`) for the eyes and the notification
   pastille. A new element anchored to the outline needs the same treatment.
@@ -83,8 +87,7 @@ Details and the reasoning behind each are in [docs/](docs/):
 - **Labels don't live in `src/bot/`.** The catalogues carry ids and the display
   resolves `t('states.orbit')`. Their ids are **literal unions** so the compiler
   checks that every entry has a label in all three languages. Adding a shape
-  without its label doesn't compile. (`StateDef.hint` is a leftover French string
-  nothing reads.)
+  without its label doesn't compile.
 - **One state isn't measured: `swirl`**, the settings view's entry transition. It's
   deliberately outside `SEQUENCE` (a test locks that) and carries both `baseBody`
   and `baseFace`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -193,8 +193,9 @@ neatness, but because that is what makes the compiler check that every entry has
 its label in all three languages. Adding a shape without its label doesn't
 compile.
 
-One exception, and it's an oversight rather than a design: `StateDef.hint` still
-holds a hardcoded French string per state. Nothing reads it.
+There used to be one exception, `StateDef.hint`: a hardcoded French string per state that
+nothing read. It is gone — a label in `src/bot/` contradicts the rule above, and this
+field would have gone out in a public type.
 
 ## One state is not measured: `swirl`
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -626,19 +626,19 @@ const etatExport = ref<EtatExport>('pret')
 let confirmation: ReturnType<typeof setTimeout> | undefined
 
 /**
- * Exporte l'avatar tel qu'il est AFFICHE : `ExportBar` ne fait que demander un
- * format, le SVG a capturer est ici, comme le montage et les skins.
- *
- * Ce que l'utilisateur voit est bien ce qu'il obtient, au cadrage pres — c'est
- * le noeud vivant qui est serialise, pas un second rendu monte a cote.
- */
-/**
  * Fond du GIF, et boite qui le demande. Le GIF est le SEUL format a poser la
  * question : lui seul a une transparence sur un bit, donc un bord dur a arbitrer.
  */
 const fondGif = ref<FondGif>(FOND_GIF_DEFAUT)
 const dialogueGif = ref(false)
 
+/**
+ * Exporte l'avatar tel qu'il est AFFICHE : `ExportBar` ne fait que demander un
+ * format, le SVG a capturer est ici, comme le montage et les skins.
+ *
+ * Ce que l'utilisateur voit est bien ce qu'il obtient, au cadrage pres — c'est
+ * le noeud vivant qui est serialise, pas un second rendu monte a cote.
+ */
 async function exporte(id: ActionId, confirme = false) {
   // Garde SYNCHRONE, en plus du `disabled` du bouton : celui-ci n'existe qu'apres
   // un rendu, donc deux clics dans la meme image telechargeaient deux fois.

--- a/src/bot/cycles.test.ts
+++ b/src/bot/cycles.test.ts
@@ -17,7 +17,7 @@ import {
   type Cycle,
   uniqueName
 } from './cycles'
-import { SEQUENCE, STATE_BY_ID } from './states'
+import { SEQUENCE, STATES, STATE_BY_ID } from './states'
 
 describe('cycle par defaut', () => {
   it('reprend la sequence relevee sur la video, dans l ordre', () => {
@@ -170,6 +170,18 @@ describe('relecture du stockage', () => {
     const blocs = Array.from({ length: 5000 }, () => ({ state: 'idle', duration: 10 }))
     const raw = JSON.stringify([{ id: 'c1', name: 'A', blocks: blocs }])
     expect(parseCycles(raw)[0]!.blocks).toHaveLength(MAX_BLOCS)
+  })
+
+  /*
+   * Le plancher est DERIVE du plus long `morph`, il n'est plus ecrit a la main. Ce test
+   * garde le lien visible : il valait 0,6 en dur, ce qui ne marchait que parce que 0,6
+   * etait justement le morph d'`orbit`. Un etat qui morphe plus lentement le suit.
+   */
+  it('le plancher de bloc couvre le plus long fondu du catalogue', () => {
+    const plusLong = Math.max(...STATES.map((s) => s.morph))
+    expect(MIN_BLOCK).toBeGreaterThanOrEqual(plusLong)
+    // et il n'est pas gratuitement plus grand : c'est exactement ce fondu
+    expect(MIN_BLOCK).toBe(plusLong)
   })
 
   it('borne aussi l ajout depuis l editeur, pas seulement la relecture', () => {

--- a/src/bot/cycles.ts
+++ b/src/bot/cycles.ts
@@ -1,4 +1,4 @@
-import { SEQUENCE, STATE_BY_ID, type StateId } from './states'
+import { SEQUENCE, STATES, STATE_BY_ID, type StateId } from './states'
 
 /**
  * Un cycle est un montage : une suite de blocs, chacun un etat tenu pendant une
@@ -23,11 +23,15 @@ export interface Cycle {
 
 /**
  * Plancher commun a tous les blocs. Le moteur ne garde qu'une case d'historique
- * (`BotEngine.setState` ecrase `prev`), donc un bloc plus court que le fondu
- * d'entree du bloc suivant — 0,6 s pour le plus long, celui d'`orbit` — saute a
- * l'image au lieu de se fondre.
+ * (`BotEngine.setState` ecrase `prev`), donc un bloc plus court que le fondu d'entree du
+ * bloc suivant saute a l'image au lieu de se fondre.
+ *
+ * DERIVE du catalogue et non ecrit a la main. La valeur etait 0,6, ce qui marchait
+ * uniquement parce que 0,6 se trouvait etre le plus long `morph` du catalogue — celui
+ * d'`orbit`. Rien ne le garantissait : ajouter un etat qui morphe en 0,8 s aurait fait
+ * trembler l'editeur sans qu'aucun test ne bronche. Maintenant le plancher suit.
  */
-export const MIN_BLOCK = 0.6
+export const MIN_BLOCK = Math.max(...STATES.map((s) => s.morph))
 
 /**
  * Garde-fou d'editeur, pas une mesure : allonger un bloc est sans risque (les

--- a/src/bot/engine.ts
+++ b/src/bot/engine.ts
@@ -12,7 +12,7 @@ import {
   type Point,
   type Silhouette
 } from './shape'
-import { STATE_BY_ID, STATES, type Pose, type StateDef, type StateId } from './states'
+import { STATE_BY_ID, type Pose, type StateDef, type StateId } from './states'
 
 export interface RenderedEye {
   d: string
@@ -473,4 +473,3 @@ export class BotEngine {
   }
 }
 
-export { STATES }

--- a/src/bot/repere.ts
+++ b/src/bot/repere.ts
@@ -1,0 +1,31 @@
+/**
+ * Le repere de tout ce que le moteur rend.
+ *
+ * `engine.sample()` sort des coordonnees en unites de viewBox, et ces deux nombres en sont
+ * la definition : sans eux, une sortie du moteur ne veut rien dire. Ils vivaient dans
+ * `BloubBot.vue`, donc hors d'atteinte — un `<script setup>` n'exporte rien — et
+ * `export.ts` en redisait un a la main avec le commentaire qui nommait le probleme.
+ *
+ * Ils sont ici parce que `src/bot/` est ce qui se lit et se consomme du dehors : le
+ * composant Vue est UN client du moteur, pas sa definition.
+ */
+
+/**
+ * Rayon de la boule au repos, en unites de viewBox. C'est le `scale` que le composant
+ * passe a `BotEngine`.
+ *
+ * Choisi et non mesure : c'est l'unite de travail. Tout le reste du dossier s'exprime en
+ * fractions de ce rayon, ce qui rend les mesures relevees sur la video independantes de la
+ * taille d'affichage.
+ */
+export const RAYON = 100
+
+/**
+ * Demi-cote du viewBox affiche. La marge au-dela du rayon loge les anneaux.
+ *
+ * Ce n'est pas une valeur libre : les anneaux de l'orbite et le swoosh de la comete montent
+ * a 1,4 fois le rayon, soit 140. Rien ne les borne au runtime — c'est le reglage a la main
+ * des tableaux `RINGS` et `SWOOSH` (`decor.ts`) qui les tient sous 158, et un test le
+ * verrouille.
+ */
+export const DEMI_VIEWBOX = 158

--- a/src/bot/states.ts
+++ b/src/bot/states.ts
@@ -167,7 +167,6 @@ export type StateId =
 
 export interface StateDef {
   id: StateId
-  hint: string
   /** duree de maintien quand la sequence complete est jouee */
   duration: number
   /**
@@ -207,7 +206,6 @@ function dotPulse(t: number, index: number): number {
 export const STATES: StateDef[] = [
   {
     id: 'idle',
-    hint: 'Boule, yeux gélules inclinés, dérive du regard et clignements',
     duration: 2.4,
     morph: 0.45,
     blinkIn: false,
@@ -218,7 +216,6 @@ export const STATES: StateDef[] = [
 
   {
     id: 'thinking',
-    hint: 'Trois points, onde de pulsation de gauche à droite',
     duration: 2.6,
     morph: 0.4,
     baseFace: false,
@@ -248,7 +245,6 @@ export const STATES: StateDef[] = [
 
   {
     id: 'wink',
-    hint: 'Œil extérieur fermé en tiret, œil intérieur grand ouvert',
     duration: 1.6,
     morph: 0.3,
     blinkIn: true,
@@ -269,7 +265,6 @@ export const STATES: StateDef[] = [
 
   {
     id: 'wide',
-    hint: 'Yeux deux fois plus grands, regard vers le bas',
     duration: 1.8,
     morph: 0.55,
     blinkIn: true,
@@ -285,7 +280,6 @@ export const STATES: StateDef[] = [
 
   {
     id: 'alert',
-    hint: "Point d'exclamation penché qui traverse en vibrant",
     duration: 2.4,
     // le "!" revient en place a 1.6 + 0.4
     minDuration: 2,
@@ -322,7 +316,6 @@ export const STATES: StateDef[] = [
 
   {
     id: 'notify',
-    hint: 'Pastille bleue sur le contour, encoche creusée, gros yeux ronds',
     duration: 2.2,
     morph: 0.5,
     blinkIn: true,
@@ -351,7 +344,6 @@ export const STATES: StateDef[] = [
 
   {
     id: 'exclaim',
-    hint: "Point d'exclamation vertical, barre tronconique",
     duration: 2,
     morph: 0.45,
     baseFace: false,
@@ -367,7 +359,6 @@ export const STATES: StateDef[] = [
 
   {
     id: 'sleep',
-    hint: 'Réduction en un point qui rebondit verticalement',
     duration: 2.4,
     morph: 0.5,
     baseFace: false,
@@ -383,7 +374,6 @@ export const STATES: StateDef[] = [
 
   {
     id: 'egg',
-    hint: 'Même hauteur que la boule, rétréci en largeur, plus large en bas',
     duration: 1.8,
     morph: 0.4,
     baseFace: false,
@@ -401,7 +391,6 @@ export const STATES: StateDef[] = [
 
   {
     id: 'hexagon',
-    hint: 'Hexagone pointe en haut, coins très arrondis',
     duration: 1.6,
     morph: 0.4,
     baseFace: false,
@@ -418,7 +407,6 @@ export const STATES: StateDef[] = [
 
   {
     id: 'play',
-    hint: "Triangle arrondi, bouquet d'arcs colorés qui le balaie",
     duration: 2,
     morph: 0.5,
     baseFace: false,
@@ -445,7 +433,6 @@ export const STATES: StateDef[] = [
 
   {
     id: 'orbit',
-    hint: 'Anneaux arc-en-ciel en orbite 3D, le triangle tourne puis se relâche',
     duration: 3.4,
     // le corps a fini de se relacher du triangle vers la boule a 1.6 + 0.9
     minDuration: 2.5,
@@ -512,7 +499,6 @@ export const STATES: StateDef[] = [
      * catalogue, c'est une transition d'interface.
      */
     id: 'swirl',
-    hint: 'Anneaux arc-en-ciel courts, entree de la vue des reglages',
     // un peu plus que le tour du regard (`TURN_TIME`, 1,1 s) : les yeux doivent
     // etre poses a gauche avant que les anneaux ne s'effacent
     duration: 1.3,
@@ -539,7 +525,6 @@ export const STATES: StateDef[] = [
 
   {
     id: 'burst',
-    hint: 'Le corps se disperse en particules qui spiralent puis se recompose',
     duration: 2.6,
     // le corps est recompose a 1.7 + 0.7
     minDuration: 2.4,
@@ -562,7 +547,6 @@ export const STATES: StateDef[] = [
 
   {
     id: 'comet',
-    hint: 'Le point reste au centre, la traînée arc-en-ciel lui tourne autour',
     duration: 2.4,
     // le point se recompose a 1.85 + 0.6 = 2.45, soit 0.05 s apres la coupe de
     // la video : ce reliquat se termine pendant le fondu suivant, comme dans la

--- a/src/components/BloubBot.vue
+++ b/src/components/BloubBot.vue
@@ -17,6 +17,7 @@ import {
   mixHex
 } from '@/bot/skins'
 import { blockAt, defaultCycle, offsetOf, type Block } from '@/bot/cycles'
+import { DEMI_VIEWBOX, RAYON } from '@/bot/repere'
 import { STATE_BY_ID, type StateId } from '@/bot/states'
 
 const props = withDefaults(
@@ -80,9 +81,11 @@ const playing = defineModel<boolean>('playing', { default: false })
 /** Temps ecoule dans le bloc courant, pour la tete de lecture de la timeline. */
 const elapsed = defineModel<number>('elapsed', { default: 0 })
 
-/** Rayon de la boule au repos en unites de viewBox ; la marge loge les anneaux. */
-const R = 100
-const VB = 158
+// Le repere vient de `src/bot/` : c'est lui qui definit ce que le moteur rend, le
+// composant n'en est qu'un client. Les noms courts restent, ils sont partout dans le
+// gabarit.
+const R = RAYON
+const VB = DEMI_VIEWBOX
 
 const shapeRadii = computed(() => SHAPE_BY_ID.get(props.shape)?.radii ?? null)
 const ink = computed(() => COLOR_BY_ID.get(props.color)?.hex ?? '#0a0a0c')

--- a/src/ui/export.test.ts
+++ b/src/ui/export.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { RAYON } from '@/bot/repere'
 import { SHAPES } from '@/bot/skins'
 import {
   ACTIONS,
@@ -23,7 +24,7 @@ import {
 } from './export'
 
 /** Rayon de la boule au repos, cf. le `R` de BloubBot.vue. */
-const RAYON_BOULE = 100
+
 
 /** Demi-cote du viewBox affiche a l'ecran, cf. le `VB` de BloubBot.vue. */
 const VB_ECRAN = 158
@@ -36,14 +37,14 @@ describe('cadre d export', () => {
    */
   it('contient toutes les formes du personnalisateur', () => {
     for (const forme of SHAPES) {
-      const rayon = Math.max(...forme.radii) * RAYON_BOULE
+      const rayon = Math.max(...forme.radii) * RAYON
       expect(rayon, `la forme « ${forme.id} » depasse du cadre`).toBeLessThan(DEMI_CADRE)
     }
   })
 
   it('laisse une marge pour le rognage circulaire d une photo de profil', () => {
     // La boule au repos ne doit pas toucher le bord : entre 70 % et 90 % du cadre.
-    const remplissage = RAYON_BOULE / DEMI_CADRE
+    const remplissage = RAYON / DEMI_CADRE
     expect(remplissage).toBeGreaterThan(0.7)
     expect(remplissage).toBeLessThan(0.9)
   })

--- a/src/ui/export.ts
+++ b/src/ui/export.ts
@@ -4,15 +4,8 @@
  * vit dans `capture.ts`, elle, parce qu'elle a besoin d'un canvas.
  */
 
+import { DEMI_VIEWBOX, RAYON } from '@/bot/repere'
 import { SHAPES } from '@/bot/skins'
-
-/**
- * Rayon de la boule au repos, en unites de viewBox : c'est le `scale` que
- * BloubBot.vue passe a `BotEngine` (son `R`). Redit ici et non importe parce
- * qu'un `<script setup>` ne peut rien exporter. Ce qui compte est verrouille
- * par un test : le cadre doit contenir TOUTES les formes.
- */
-const RAYON_BOULE = 100
 
 /**
  * Marge autour de la forme la plus large. Huit pour cent : c'est ce qui permet
@@ -41,7 +34,7 @@ export const RAYON_MAX = Math.max(...SHAPES.map((forme) => Math.max(...forme.rad
  * pareil a l'oeil », or les recadrer separement remettrait chacune a la meme
  * taille et casserait ce reglage.
  */
-export const DEMI_CADRE = Math.ceil(RAYON_BOULE * RAYON_MAX * MARGE)
+export const DEMI_CADRE = Math.ceil(RAYON * RAYON_MAX * MARGE)
 
 /** viewBox du document exporte, centre sur la boule. */
 export function viewBoxExport(demi = DEMI_CADRE) {
@@ -49,17 +42,14 @@ export function viewBoxExport(demi = DEMI_CADRE) {
 }
 
 /**
- * Demi-cote du viewBox de l'ECRAN, cf. le `VB` de BloubBot.vue.
+ * Demi-cote du viewBox de l'ECRAN.
  *
- * C'est celui qu'il faut pour exporter un CYCLE, et pas le cadre serre : la marge
- * que le cadre serre supprime est justement celle qui loge les anneaux des etats
- * animes. Ils montent a 1,4 fois le rayon de la boule, soit 140 — donc au-dela des
- * 125 du cadre serre, qui les rognerait. Un test le verrouille.
- *
- * Rien ne borne ces rayons au runtime : c'est le reglage a la main des tableaux
- * `RINGS` et `SWOOSH` (decor.ts) qui les tient sous 158.
+ * C'est celui qu'il faut pour exporter un CYCLE, et pas le cadre serre : la marge que le
+ * cadre serre supprime est justement celle qui loge les anneaux des etats animes. Ils
+ * montent a 1,4 fois le rayon de la boule, soit 140 — donc au-dela des 125 du cadre serre,
+ * qui les rognerait. Un test le verrouille.
  */
-export const DEMI_ECRAN = 158
+export const DEMI_ECRAN = DEMI_VIEWBOX
 
 export type ActionId = 'png' | 'svg' | 'anime' | 'gif' | 'copie' | 'copieSvg'
 

--- a/src/ui/timeline.test.ts
+++ b/src/ui/timeline.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { BASE_SCALE, clampZoom, MAX_ZOOM, MIN_ZOOM, mmss, ticksFor } from './timeline'
+import * as timeline from './timeline'
 
 describe('mise en forme', () => {
   it('ecrit le temps en minutes et secondes', () => {
@@ -10,7 +11,18 @@ describe('mise en forme', () => {
     expect(mmss(-3)).toBe('0:00')
   })
 
-  it('ecrit les durees a la francaise', () => {
+  /*
+   * Ce test etait VIDE : il ne verifiait rien et comptait quand meme dans le total. Il
+   * restait de l'epoque ou la mise en forme localisee vivait ici. On lui fait donc dire ce
+   * qu'il pretendait — que ce module reste PUR, sans langue.
+   *
+   * Le separateur decimal change avec la langue et l'unite se traduit, donc les durees en
+   * secondes passent par `secondes` / `secondesCourtes` de `@/i18n`. `mmss` reste ici : le
+   * format mm:ss n'a ni unite ni separateur decimal.
+   */
+  it('ne met en forme aucune duree localisee : ca appartient a i18n', () => {
+    expect(Object.keys(timeline).filter((n) => /^secondes/.test(n))).toEqual([])
+    expect(mmss(65)).toBe('1:05')
   })
 
 })


### PR DESCRIPTION
Small debts, all verified. They matter because `src/bot/` is meant to become a public surface.

**The geometry constants lived in a `.vue`.** `R = 100` and `VB = 158` are the frame of everything `sample()` returns, and a consumer had no way to obtain them — a `<script setup>` exports nothing. `export.ts` redeclared one by hand with a comment that named the problem exactly. They now live in `src/bot/repere.ts` as `RAYON` and `DEMI_VIEWBOX`, imported by `BloubBot.vue`, `export.ts` and `export.test.ts`. Three duplications gone. The Vue component is a *client* of the engine, not its definition.

**`MIN_BLOCK` held by coincidence.** `0.6` protected the timeline from a frame-jump only because 0.6 happened to be the longest `morph` in the catalogue (`orbit`). Nothing guaranteed it: adding a state that morphs in 0.8 s would have made the editor jitter with no test complaining. It is now **derived** — `Math.max(...STATES.map(s => s.morph))` — not merely tested, plus a test that keeps the link visible.

**Dead code.** `export { STATES }` from `engine.ts` was a dead re-export (everyone takes `STATES` from `./states`). `StateDef.hint` held 15 hardcoded French strings that nothing read, contradicting the rule that labels don't live in `src/bot/` — and it would have shipped inside a public type. Both removed; the bundle drops from 63.56 to 63.04 kB gzip. `get state()` was **kept**: it is exactly the accessor that fixes the joint-frame defect from the export task.

**A test that passed on nothing.** `ui/timeline.test.ts` had an empty `it('ecrit les durees a la francaise')` counting towards the total, left over from when localised formatting lived there. It now asserts what it claimed: that the module exports no localised formatter, because the decimal separator and the unit are language-dependent and belong to `@/i18n`.

**An orphaned doc block.** The comment describing `exporte()` had drifted above `const fondGif` after an insertion. Put back on its function.

Nothing changes on screen, and that is checked byte for byte: `sample(1)` on `idle` still returns `matrix(0.87,-0.33,0.45,0.84,21.42,-43.32)` and `matrix(0.64,-0.06,0.45,0.84,62.98,-53.9)`, the two matrices `public/favicon.svg` claims to hold. `DEMI_ECRAN` is still 158, `DEMI_CADRE` still 125, `MIN_BLOCK` still 0.6.

`CLAUDE.md` and `docs/architecture.md` both described `StateDef.hint` as existing; corrected, with a line added for `repere.ts`.

`pnpm build` and `pnpm test` (195 tests) pass, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)