### PR TITLE
CI: stop running twice on a PR branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,10 @@
 name: ci
-on: [push, pull_request]
+# `push` limite a main, sinon chaque branche de PR declenche DEUX fois le meme job — une
+# fois pour le push, une fois pour la PR — sur exactement le meme commit.
+on:
+  push:
+    branches: [main]
+  pull_request:
 jobs:
   verifie:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`on: [push, pull_request]` fired the same job twice for every PR branch — once for the push, once for the pull request, on exactly the same commit. Visible in the checks list of every PR so far: two `verifie` entries.

`push` is now limited to `main`, which keeps the gate where it matters (a red `main` is the thing to prevent) without the duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)