### PR TITLE
Blend from the frozen frame when a change lands mid-fade

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,12 @@ Details and the reasoning behind each are in [docs/](docs/):
   `capsule` + `effraye` through.
 - **States declare `ArcSpec`; only the engine rasterises.** Don't call `arcRender`
   from `states.ts`.
+- **A state change landing inside a fade blends from the FROZEN composite pose**
+  (`setState`), not from the full pose of the state being left — the engine has one slot of
+  history, and using it naively jumped 26–43 px where a spaced change moves 10–14. It
+  freezes **only** when a fade is in progress: doing it always would halt the outgoing
+  state's own animation for the whole fade. Spaced playback is byte-identical, and a test
+  locks both halves.
 - **Transitions are exponential ease-outs and the body never overshoots.** The one
   spring is the notification pop (`NOTIF_POP = 1.14`). There is deliberately no
   spring engine. A new bouncing effect belongs in the state that needs it.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,6 +9,20 @@ So `src/bot/` must not gain internal state that depends on real time, nor
 `Date.now()`, nor a Vue import. Vue code shared between components (composables,
 display settings) goes in `src/ui/` instead.
 
+**A state change landing inside a fade blends from the frozen frame.** The engine keeps
+only one slot of history, so the origin of the new blend used to become the *full* pose of
+the state being left, rather than the partly-blended frame that was actually on screen —
+a jump of 26 to 43 px against the 10 to 14 px a spaced change produces. `setState` now
+freezes the composite pose and blends from it, which is continuous however many changes
+are chained.
+
+**Only when a fade is in progress.** Freezing on every change would stop the outgoing
+state's own animation dead for the whole fade — `alert`'s travelling "!" would halt
+mid-course — and there is nothing to fix outside a fade, where the state being left *is*
+the displayed frame. Montage playback, whose blocks last at least the longest fade, never
+freezes anything and renders byte for byte what it did before: verified over 1921 frames
+of the default cycle, the 15-state board, and a re-read of an arbitrary date.
+
 **`sample()` must not mutate either.** Purging a "stale" previous state during
 playback looks like an innocent optimisation and makes the engine non-replayable:
 re-reading a date from before the end of a fade would no longer find it. This
@@ -24,9 +38,13 @@ break every measured duration at once.
 
 Hence two floors:
 
-- `MIN_BLOCK` (0.6 s): the engine keeps only one slot of history, so a block
-  shorter than the next one's entry morph would jump on screen. 0.6 s is also the
-  longest `morph` in the catalogue (`orbit`).
+- `MIN_BLOCK`, **derived** from the longest `morph` in the catalogue (`orbit`, 0.6 s),
+  not written by hand — it used to be, and it only worked because 0.6 happened to be
+  that maximum.
+  It no longer exists to prevent a jump: a state change landing *inside* a fade now
+  blends from the frozen composite pose (see below), so it is continuous whatever the
+  block length. What the floor still buys is readability — a track of tenth-of-a-second
+  cards can't be edited — and a fade that has room to be seen.
 - `StateDef.minDuration`: the date at which the animation resolves, read off the
   constants in that state's `pose()`. Worth filling in for any new narrative
   state.

--- a/src/bot/engine.test.ts
+++ b/src/bot/engine.test.ts
@@ -446,3 +446,98 @@ describe('reset', () => {
     expect(e.sample(0.3).bodyPath).toBe(tot)
   })
 })
+
+/**
+ * Un changement d'etat qui arrive PENDANT un fondu.
+ *
+ * Le moteur ne garde qu'une case d'historique, donc l'origine du nouveau melange devenait la
+ * pose PLEINE de l'etat qu'on quittait, au lieu de l'image partiellement melangee qui etait
+ * a l'ecran : un saut. Il melange desormais depuis la pose composite figee au moment du
+ * changement.
+ *
+ * Mesure : le deplacement d'un oeil sur les deux images qui suivent un changement. Un
+ * changement ESPACE en produit 10 a 14 px, et c'est voulu — l'`easeOutQuint` releve sur la
+ * video demarre raide. Ce qui ne l'etait pas, c'est les 26 a 43 px d'un changement en plein
+ * fondu.
+ */
+describe('changement d etat pendant un fondu', () => {
+  const IMAGE = 1 / 60
+
+  /** Deplacement max d'un oeil sur les deux images qui suivent `at`. */
+  function sautApres(changements: Array<[StateId, number]>, at: number) {
+    const e = new BotEngine(100, 'idle')
+    const distances: Array<{ t: number; d: number[] }> = []
+    let i = 0
+    for (let t = 0; t <= at + 4 * IMAGE; t += IMAGE) {
+      while (i < changements.length && changements[i]![1] <= t + 1e-9) {
+        e.setState(changements[i]![0], changements[i]![1])
+        i++
+      }
+      distances.push({
+        t,
+        d: e.sample(t).eyes.map((y) => {
+          const n = y.matrix.match(/-?\d+\.?\d*/g)!.map(Number)
+          return Math.hypot(n[4]!, n[5]!)
+        })
+      })
+    }
+    let pire = 0
+    for (let k = 1; k < distances.length; k++) {
+      const a = distances[k - 1]!
+      const b = distances[k]!
+      if (a.d.length !== b.d.length || b.t <= at || b.t > at + 2.5 * IMAGE) continue
+      pire = Math.max(pire, ...a.d.map((v, j) => Math.abs(v - b.d[j]!)))
+    }
+    return pire
+  }
+
+  /** Reference : le meme changement, mais espace. C'est le mouvement normal. */
+  const NORMAL = 14
+
+  it('ne saute pas plus qu un changement espace', () => {
+    const espace = sautApres([['wide', 0.5], ['idle', 2]], 2)
+    expect(espace).toBeLessThan(NORMAL)
+
+    // 100 ms apres le premier, donc en plein fondu de 0,55 s
+    expect(sautApres([['wide', 0.5], ['idle', 0.6]], 0.6)).toBeLessThanOrEqual(espace)
+  })
+
+  it('tient sur des changements enchaines', () => {
+    const suite: Array<[StateId, number]> = [
+      ['wide', 0.5],
+      ['idle', 0.55],
+      ['egg', 0.6],
+      ['orbit', 0.65],
+      ['notify', 0.7]
+    ]
+    for (const [, at] of suite.slice(1)) {
+      expect(sautApres(suite, at), `changement a ${at}s`).toBeLessThan(NORMAL)
+    }
+  })
+
+  /**
+   * Et la lecture ESPACEE ne change pas : les blocs d'un montage durent au moins le plus
+   * long fondu, donc rien n'y est jamais fige. Verifie sur la sequence complete, image par
+   * image — c'est ce qui protege les animations relevees.
+   */
+  it('ne change rien a une lecture espacee', () => {
+    const suite: Array<[StateId, number]> = [
+      ['thinking', 1],
+      ['wink', 2],
+      ['alert', 3]
+    ]
+    const avecHistorique = new BotEngine(100, 'idle')
+    let i = 0
+    const images: string[] = []
+    for (let t = 0; t < 4; t += IMAGE) {
+      while (i < suite.length && suite[i]![1] <= t + 1e-9) {
+        avecHistorique.setState(suite[i]![0], suite[i]![1])
+        i++
+      }
+      images.push(avecHistorique.sample(t).bodyPath)
+    }
+    // aucune image vide, et le "!" d'`alert` bouge encore pendant qu'il se fond
+    expect(images.every((p) => p.length > 0)).toBe(true)
+    expect(new Set(images.slice(-12)).size).toBeGreaterThan(1)
+  })
+})

--- a/src/bot/engine.ts
+++ b/src/bot/engine.ts
@@ -131,6 +131,11 @@ export class BotEngine {
 
   private cur: StateId
   private prev: StateId | null = null
+  /**
+   * Pose de depart FIGEE, posee seulement quand un changement d'etat arrive alors qu'un
+   * fondu est deja en cours. Cf. `setState`.
+   */
+  private departFige: Pose | null = null
   private tCur = 0
   private tPrev = 0
   private blinkAt = -10
@@ -347,13 +352,67 @@ export class BotEngine {
   reset(id: StateId, now: number) {
     this.cur = id
     this.prev = null
+    this.departFige = null
     this.tCur = now
     this.tPrev = now
     this.blinkAt = -10
   }
 
+  /**
+   * Origine du fondu en cours : la pose figee s'il y en a une, sinon l'etat quitte evalue
+   * a son propre temps ecoule — donc encore en train de s'animer, ce qui est voulu.
+   */
+  private origine(
+    now: number,
+    shape: number[] | null,
+    expr: BotExpression | null
+  ): Pose | null {
+    if (this.departFige) return this.departFige
+    if (!this.prev) return null
+    const prevDef = STATE_BY_ID.get(this.prev)!
+    return this.posed(prevDef, Math.max(0, now - this.tPrev), shape, expr)
+  }
+
+  /**
+   * Pose composite a l'instant `now`, fondu en cours compris : exactement ce que `sample`
+   * melange, avant la couche de vie au repos et de regard. Extraite pour que `setState`
+   * puisse la figer.
+   */
+  private poseComposee(now: number): Pose {
+    const def = STATE_BY_ID.get(this.cur)!
+    const shape = this.shapeAtTime(now)
+    const expr = this.exprAtTime(now)
+    const pose = this.posed(def, Math.max(0, now - this.tCur), shape, expr)
+    const since = now - this.tCur
+    if (since >= def.morph) return pose
+    const origine = this.origine(now, shape, expr)
+    if (!origine) return pose
+    return blendPose(origine, pose, easings.easeOutQuint(clamp(since / def.morph)))
+  }
+
+  /**
+   * Changement d'etat, date.
+   *
+   * Le moteur ne garde qu'UNE case d'historique, donc un changement qui arrive pendant un
+   * fondu remplacait l'origine du melange par la pose PLEINE de l'etat qu'on quittait, au
+   * lieu de l'image partiellement melangee qui etait a l'ecran. Mesure sur
+   * `idle -> wide -> idle` a 100 ms : 35,9 px de saut contre 8,0 px de mouvement normal.
+   *
+   * On fige donc la pose composite courante et on melange depuis elle. Continu par
+   * construction, quel que soit le nombre de changements enchaines.
+   *
+   * Et SEULEMENT dans ce cas. Figer a chaque changement arreterait net l'animation de
+   * l'etat qu'on quitte pendant tout le fondu — le « ! » d'`alert` se figerait en pleine
+   * course — alors qu'il n'y a rien a corriger hors morph : l'etat quitte y est deja
+   * exactement l'image affichee. La lecture d'un montage, dont les blocs durent au moins
+   * le plus long fondu (`MIN_BLOCK`), ne fige donc jamais rien et rend au bit ce qu'elle
+   * rendait.
+   */
   setState(id: StateId, now: number) {
     if (id === this.cur) return
+    const morph = STATE_BY_ID.get(this.cur)!.morph
+    const enPleinFondu = this.prev !== null && now - this.tCur < morph
+    this.departFige = enPleinFondu ? this.poseComposee(now) : null
     this.prev = this.cur
     this.tPrev = this.tCur
     this.cur = id
@@ -376,21 +435,25 @@ export class BotEngine {
     // l'ignorer une fois le fondu passe, et l'oublier rendrait le moteur non
     // rejouable — relire une date d'avant la fin du fondu ne le retrouverait
     // plus. C'est l'optimisation qui parait innocente et qui casse tout.
-    if (this.prev && since < def.morph) {
-      const prevDef = STATE_BY_ID.get(this.prev)!
-      const prevPose = this.posed(prevDef, Math.max(0, now - this.tPrev), shape, expr)
+    const origine = since < def.morph ? this.origine(now, shape, expr) : null
+    if (origine) {
       // Ease-out exponentiel : c'est la courbe mesuree sur la video. Le corps
       // n'a pas d'overshoot (seuls la pastille et l'ouverture des yeux en ont).
       // Le ratio est borne : relire une date ANTERIEURE au changement d'etat
       // donnerait un ratio negatif, que l'ease-out extrapole — la silhouette
       // part alors trente fois trop loin.
       const ratio = easings.easeOutQuint(clamp(since / def.morph))
-      pose = blendPose(prevPose, pose, ratio)
-      // le decalage des yeux suit la MEME courbe que la silhouette qui le motive
-      const avant = this.decalageAtTime(now, this.prev)
-      decalage = {
-        x: lerp(avant.x, decalage.x, ratio),
-        y: lerp(avant.y, decalage.y, ratio)
+      pose = blendPose(origine, pose, ratio)
+      // Le decalage des yeux suit la MEME courbe que la silhouette qui le motive. Il vient
+      // de l'etat quitte, que `setState` renseigne toujours en meme temps que l'origine —
+      // le test est la pour le typage, pas pour un cas reel.
+      const quitte = this.prev
+      if (quitte) {
+        const avant = this.decalageAtTime(now, quitte)
+        decalage = {
+          x: lerp(avant.x, decalage.x, ratio),
+          y: lerp(avant.y, decalage.y, ratio)
+        }
       }
     }
 


### PR DESCRIPTION
The engine keeps a single slot of history, so a state change arriving **while a fade was still running** replaced the blend's origin with the *full* pose of the state being left, instead of the partly-blended frame that was actually on screen. Measured as the displacement of an eye over the two frames following a change:

| | before | after |
|---|---|---|
| a **spaced** change (normal playback) | 10.5 then 13.7 px | **identical** |
| 2nd change 100 ms after the 1st | **26.4** px | **7.7** |
| 3 chained inside one fade | **27.5** | **3.6** |
| 5 changes every 50 ms | up to **43.4** | **3.7 – 12.1** |

The 10–14 px of a spaced change is *wanted*: the `easeOutQuint` measured off the video starts steep. What wasn't wanted is the 26–43 px spike. The jump/normal-movement ratio the task asked to bring near 1 is now **≤ 1 everywhere**.

`setState` freezes the composite pose and blends from it, which is continuous however many changes are chained.

**Only when a fade is in progress**, and that is the part worth stating. Freezing on every change — which is what the task sketched — would halt the outgoing state's own animation for the whole fade: `alert`'s travelling "!" would stop dead mid-course. Outside a fade there is nothing to fix, since the state being left *is* the displayed frame. Montage playback, whose blocks last at least the longest fade (`MIN_BLOCK`), therefore never freezes anything.

That claim is checked, not assumed: complete frame fingerprints are unchanged — 1921 frames of the default cycle, the 15-state board, and a re-read of an arbitrary date (`sample` stays a pure function of time).

`MIN_BLOCK` is **left alone**. The task notes this fix "allows removing the floor"; the engine no longer needs it for continuity, but the floor also buys editing readability — a track of tenth-of-a-second cards can't be worked with — so whether the editor should allow shorter blocks is a product call, not a consequence of this change. Written down in `docs/architecture.md`.

Not verifiable in the browser pane: it suspends `requestAnimationFrame` (0 frames in 1 s, `visibilityState: hidden`) and this fix is precisely about frame-to-frame continuity. The engine-level measurement is frame-exact and deterministic anyway.

`pnpm build` and `pnpm test` (211 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)