### PR TITLE
Accessibility: honoured roles, live reduced motion, keyboard reordering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,15 @@ Details and the reasoning behind each are in [docs/](docs/):
   to the initial bundle, more than the 34 kB that got `vue-i18n` rejected in favour of the
   in-house layer. Behind `await import(...)` it costs 0.7 kB and only arrives when someone
   exports a video. Turning it into a top-level import would silently undo that.
+- **Don't declare `role="menu"` without the keyboard contract.** Those roles *promise*
+  arrow-key navigation and focus moved into the menu on open, and they stop exposing the
+  children as ordinary buttons. Three popups declared them and implemented none of it, so
+  the Tab order didn't match what was announced — they are plain button lists now, with
+  `aria-haspopup="true"` and `aria-expanded`. `Settings.vue` shows the other route: a real
+  `radiogroup` with a moving `tabindex`. Pick one, never the label alone.
+- **`prefers-reduced-motion` is followed at runtime, not read once**, and it draws a line:
+  it cancels box transitions and the settings view's `swirl` entry, which are decoration;
+  it does **not** cancel the breathing, gaze drift and blinking, which are what the bot IS.
 - **A UI element that must appear once uses a `transition`, not an `animation`.** An
   animation replays on every mount: every view change, every reload. A transition
   doesn't run on an element's first computed style, so it stays quiet there. That's

--- a/docs/interface.md
+++ b/docs/interface.md
@@ -120,3 +120,15 @@ Hence `ecritParNous` in `App.vue`: the fragment we just wrote is remembered and 
 `hashchange` is ignored. It is **consumed** on that first read rather than kept —
 one write fires at most one event, and a browser Back to that same state later is a
 real navigation that must still move the playhead.
+
+## Every editing gesture has a keyboard route
+
+Drag-and-drop had no equivalent, so a block could be added, removed and resized — the
+resize handle already took arrow keys — but never **reordered**, and precise seeking existed
+only on the ruler, pointer-only. It was the one gesture in the editor that was unreachable.
+
+`Alt` + left/right moves the focused card; bare arrows move the playhead by `STEP`. `Alt`
+rather than bare arrows for the move, because a card is a button inside a list and arrows
+there are expected to navigate. **The focus follows the card being moved** — otherwise the
+next press pushes a different one — which means waiting a tick, since the list is rebuilt
+and the destination button does not exist yet.

--- a/src/App.vue
+++ b/src/App.vue
@@ -96,6 +96,21 @@ const gallery = ref(initial.gallery)
  * Le repli sur `navigate` sert aux navigateurs qui ne renseignent pas l'entree :
  * dans le doute on joue, plutot que de ne jamais rien montrer.
  */
+/**
+ * « Mouvement reduit » demande par le systeme, SUIVI et pas lu une seule fois.
+ *
+ * Le reglage change en cours de session — c'est meme l'usage : on l'active quand quelque
+ * chose gene. Un `matches` lu au `setup` ignorait ce changement jusqu'au rechargement.
+ *
+ * Ce qu'il coupe est de la DECORATION : les transitions de boites et le tourbillon
+ * d'entree des reglages, choisi et non releve sur la video. Ce qu'il ne coupe pas est du
+ * CONTENU : la respiration, la derive du regard et les clignements sont ce que le bot EST,
+ * les retirer laisserait une image morte plutot qu'un mouvement apaise.
+ */
+const calmeQuery = window.matchMedia('(prefers-reduced-motion: reduce)')
+const calme = ref(calmeQuery.matches)
+calmeQuery.addEventListener('change', (e) => (calme.value = e.matches))
+
 // `getEntriesByType` est type sur le `PerformanceEntry` generique, qui n'a pas de
 // `type` : c'est l'entree de navigation qui le porte, d'ou l'annotation.
 const [nav] = performance.getEntriesByType('navigation') as PerformanceNavigationTiming[]
@@ -110,7 +125,7 @@ const intro = ref(
       named: initial.named,
       gallery: initial.gallery,
       rechargement: navigation !== 'navigate',
-      calme: window.matchMedia('(prefers-reduced-motion: reduce)').matches
+      calme: calme.value
     })
 )
 
@@ -338,11 +353,17 @@ const REST = [makeBlock('idle')]
  * meme pose : la reprise ne se voit pas.
  */
 const ENTREE = [makeBlock('swirl'), makeBlock('idle')]
+/**
+ * Sous « mouvement reduit », l'entree va droit au repos : le tourbillon est une transition
+ * d'interface, choisie et non relevee, donc de la decoration au sens de ce reglage.
+ */
+const ENTREE_CALME = [makeBlock('idle')]
 
 const played = computed(() => {
   if (intro.value) return INTRO
   if (view.value === 'animations') return cycle.value.blocks
-  return view.value === 'reglages' ? ENTREE : REST
+  if (view.value !== 'reglages') return REST
+  return calme.value ? ENTREE_CALME : ENTREE
 })
 
 watch(view, (now, before) => {

--- a/src/components/BlockPicker.vue
+++ b/src/components/BlockPicker.vue
@@ -22,6 +22,16 @@ const panel = ref<HTMLElement | null>(null)
 const position = ref<Record<string, string>>({})
 
 /**
+ * La palette est-elle ouverte ? Pour `aria-expanded`, que le declencheur doit porter comme
+ * ceux de la barre d'export et du menu de cycles.
+ *
+ * Suivi par l'evenement `toggle` du popover et non par notre propre `toggle()` : la
+ * fermeture LEGERE — clic a cote, Echap — est faite par le navigateur, donc un drapeau que
+ * nous tiendrions nous-memes resterait bloque sur « ouvert ».
+ */
+const ouvert = ref(false)
+
+/**
  * Ouvre la palette au-dessus du « + ». Elle vit dans la couche superieure du
  * navigateur, donc sa position se calcule ici, en coordonnees d'ecran, et se
  * borne pour ne pas sortir par la droite quand le bouton est en bout de piste.
@@ -63,7 +73,8 @@ function pick(state: StateId) {
     type="button"
     class="flex h-full w-full cursor-pointer items-center justify-center rounded-lg border-2 border-dashed border-[var(--line)] text-lg leading-none text-[var(--muted)] transition hover:border-[var(--muted)] hover:text-[var(--ink)]"
     :aria-label="t('timeline.addAnimation')"
-    aria-haspopup="menu"
+    aria-haspopup="true"
+    :aria-expanded="ouvert"
     @click="toggle"
   >
     +
@@ -79,7 +90,7 @@ function pick(state: StateId) {
   <div
     ref="panel"
     popover
-    role="menu"
+    @toggle="ouvert = ($event as ToggleEvent).newState === 'open'"
     class="m-0 w-72 rounded-xl bg-white p-2 shadow-lg ring-1 ring-black/5"
     :style="position"
   >

--- a/src/components/CycleMenu.vue
+++ b/src/components/CycleMenu.vue
@@ -48,7 +48,7 @@ onBeforeUnmount(() => window.removeEventListener('pointerdown', onOutside))
     <button
       type="button"
       class="flex max-w-56 cursor-pointer items-center gap-1.5 rounded-lg px-2 py-1 text-left text-sm font-medium transition hover:bg-black/5"
-      aria-haspopup="menu"
+      aria-haspopup="true"
       :aria-expanded="open"
       :title="nomDeCycle(current)"
       @click="open = !open"
@@ -75,7 +75,6 @@ onBeforeUnmount(() => window.removeEventListener('pointerdown', onOutside))
     <div
       v-if="open"
       class="absolute bottom-full left-0 z-10 mb-2 w-56 rounded-xl bg-white p-1 shadow-lg ring-1 ring-black/5"
-      role="menu"
     >
       <div
         v-for="c in cycles"
@@ -86,7 +85,6 @@ onBeforeUnmount(() => window.removeEventListener('pointerdown', onOutside))
              lieu d'etre coupe, et deborde du menu avec ses deux actions -->
         <button
           type="button"
-          role="menuitem"
           class="flex min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-lg px-2.5 py-1.5 text-left text-xs transition hover:bg-black/5"
           :title="nomDeCycle(c)"
           @click="choose(c.id)"
@@ -137,7 +135,6 @@ onBeforeUnmount(() => window.removeEventListener('pointerdown', onOutside))
 
       <button
         type="button"
-        role="menuitem"
         class="flex w-full cursor-pointer items-center gap-2 rounded-lg px-2.5 py-1.5 text-left text-xs transition hover:bg-black/5"
         @click="create"
       >

--- a/src/components/ExportBar.vue
+++ b/src/components/ExportBar.vue
@@ -105,7 +105,7 @@ onBeforeUnmount(() => window.removeEventListener('pointerdown', onOutside))
         class="flex cursor-pointer items-center px-2.5 transition hover:bg-white/10 disabled:cursor-default"
         :disabled="occupe"
         :aria-label="t('export.more')"
-        aria-haspopup="menu"
+        aria-haspopup="true"
         :aria-expanded="open"
         @click="open = !open"
       >
@@ -132,14 +132,12 @@ onBeforeUnmount(() => window.removeEventListener('pointerdown', onOutside))
 
     <div
       v-if="open"
-      role="menu"
       class="absolute right-0 bottom-full z-10 mb-2 w-60 rounded-xl border border-[var(--line)] bg-[var(--paper)] p-1 shadow-lg"
     >
       <button
         v-for="action in actions"
         :key="action.id"
         type="button"
-        role="menuitem"
         class="flex w-full cursor-pointer items-center gap-2.5 rounded-lg px-2.5 py-2 text-left text-sm transition hover:bg-black/5"
         :class="action.id === 'copie' && 'mt-1 border-t border-[var(--line)] pt-2.5'"
         @click="lance(action.id)"

--- a/src/components/TimelineTrack.vue
+++ b/src/components/TimelineTrack.vue
@@ -262,6 +262,48 @@ function onResizeKey(index: number, delta: number) {
   setDuration(index, props.blocks[index]!.duration + delta)
 }
 
+/* -------------------------------------------------------------- au clavier */
+
+/**
+ * Reordonner et pointer AU CLAVIER.
+ *
+ * Le glisser-deposer n'avait aucun equivalent : on pouvait ajouter, supprimer et etirer un
+ * bloc — la poignee gere deja les fleches — mais jamais le REORDONNER, et le pointage
+ * precis n'existait qu'au pointeur, sur la regle. C'etait le seul geste de l'editeur
+ * inaccessible.
+ *
+ * `Alt` + fleches deplace la carte, les fleches nues promenent la tete de lecture de `STEP`.
+ * Alt et pas les fleches nues pour le deplacement : une carte est un bouton dans une liste,
+ * et les fleches y servent d'abord a se deplacer.
+ *
+ * Le focus SUIT la carte deplacee, sinon on se retrouve a en pousser une autre au coup
+ * suivant. Il faut attendre le rendu : la liste est recomposee, donc le bouton d'arrivee
+ * n'existe pas encore.
+ *
+ * La carte porte `aria-keyshortcuts` : un raccourci que rien n'annonce n'est pas une
+ * affordance. C'est l'attribut fait pour ca, et il evite d'allonger l'etiquette, qui est
+ * relue a chaque carte de la piste.
+ */
+async function onCardKey(index: number, e: KeyboardEvent) {
+  const sens = e.key === 'ArrowLeft' ? -1 : e.key === 'ArrowRight' ? 1 : 0
+  if (!sens) return
+  e.preventDefault()
+
+  if (!e.altKey) {
+    // pointage : la tete de lecture avance d'un pas, dans tout le montage
+    emit('seek', Math.max(0, Math.min(total.value - 0.001, at.value + sens * STEP)))
+    return
+  }
+
+  const cible = index + sens
+  if (cible < 0 || cible >= props.blocks.length) return
+  emit('update:blocks', moveBlock(props.blocks, index, cible))
+  block.value = cible
+  await nextTick()
+  const liste = track.value?.querySelectorAll<HTMLButtonElement>('[data-carte]')
+  liste?.[cible]?.focus()
+}
+
 /* ----------------------------------------------------------------- scrub */
 
 function scrubTo(e: PointerEvent) {
@@ -349,8 +391,12 @@ function onRulerMove(e: PointerEvent) {
               @pointermove="onBlockMove"
               @pointerup="onBlockUp(i)"
               @pointercancel="drag = null"
+              data-carte
+              aria-keyshortcuts="Alt+ArrowLeft Alt+ArrowRight ArrowLeft ArrowRight"
               @keydown.enter.prevent="block = i"
               @keydown.space.prevent="block = i"
+              @keydown.left="onCardKey(i, $event)"
+              @keydown.right="onCardKey(i, $event)"
             >
               <!-- la miniature EST l'identite de la carte, comme la vignette
                    d'une page : le nom n'apprendrait rien de plus, il ne reste

--- a/src/styles.css
+++ b/src/styles.css
@@ -506,6 +506,18 @@ body,
   .barre-export {
     transition: none;
   }
+
+  /*
+   * Les boites modales manquaient a cette liste : `.dialogue` anime un
+   * `translateY(8px) scale(0.98)`, donc elles glissaient encore sous « mouvement
+   * reduit » alors que tout le reste etait neutralise. `.rail` et `.wordmark`, eux, ne
+   * jouent que sur l'opacite et n'ont rien a faire ici.
+   */
+  .dialogue,
+  .dialogue::backdrop {
+    transition: none;
+    animation: none;
+  }
 }
 
 body {


### PR DESCRIPTION
The foundation was already good — native `<dialog>` everywhere, real radio groups, `sr-only` `<h1>`, `aria-hidden` on decorative glyphs, `:lang` on the language buttons. These are the specific holes.

**1. `role="menu"` without the keyboard contract.** Three popups declared `role="menu"` / `role="menuitem"`. Those roles *promise* arrow-key navigation and focus moved into the menu on open, and they stop exposing the children as ordinary buttons — so the Tab order didn't match what was announced. `Settings.vue` already shows the other route (a real `radiogroup` with a moving `tabindex`), which is the point: pick one, never the label alone. They are plain button lists now. `BlockPicker`'s trigger gains the `aria-expanded` the other two already had, tracked through the popover's own `toggle` event — light dismiss (click outside, Escape) is done by the browser, so a flag we maintained ourselves would stay stuck on "open". Verified: `false → true → false`.

**2. `prefers-reduced-motion` skipped the dialogs.** `.dialogue` animates `translateY(8px) scale(0.98)` and wasn't in the block, so every modal still slid while everything else was neutralised. `.rail` and `.wordmark` only touch opacity and correctly stay out.

**3. Reduced motion was read once, and only for the arrival.** Now followed with `addEventListener('change')` — the setting gets turned on *during* a session, that's its whole point. It also draws a line: it cancels box transitions and the settings view's `swirl` entry, which is decoration by the project's own definition (a chosen interface transition, not measured); it does **not** cancel breathing, gaze drift and blinking, which are what the bot *is* — removing those leaves a dead image rather than a calmer one.

**4. Reordering a block was impossible by keyboard.** Add, remove and resize all worked (the resize handle already took arrow keys) but never *reorder*, and precise seeking was pointer-only. `Alt` + left/right moves the focused card, bare arrows move the playhead by `STEP`. `Alt` rather than bare arrows because a card is a button in a list and arrows there are expected to navigate. The focus **follows** the moved card — otherwise the next press pushes a different one — which needs a tick, since the list is rebuilt. The card carries `aria-keyshortcuts`: a shortcut nothing announces is not an affordance, and that attribute avoids padding the label that is re-read on every card.

Verified in the browser: `Alt+→` moves a card and the focus follows it, `Alt+←` puts it back; the duration handle is a *sibling* button so `Alt+→` there moves nothing while a bare arrow still resizes; three views render, 0 console errors.

One thing relied on review rather than execution, and it is the only one in the batch: the `swirl` skip under reduced motion. Its rings only appear from t = 0.05 s and the browser pane suspends `requestAnimationFrame`, so the app never reaches that frame there.

`pnpm build` and `pnpm test` (211 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)