### PR TITLE
Changelog and 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,72 @@
+# Changelog
+
+Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1] — 2026-08-17
+
+First batch of post-launch fixes. Every entry was reproduced and measured before being
+fixed, and the measurement is in the commit that fixes it.
+
+### Fixed
+
+- **Playback could never get past a repeated animation.** Writing `#etat=` fired a
+  `hashchange` the listener read as an incoming navigation, and the lookup returns a
+  state's *first* occurrence — so a montage holding the same animation twice looped
+  forever on the first one. One click in the palette was enough to trigger it.
+- **Three image defects in the montage export**, none visible short of stepping through
+  an MP4 frame by frame: one corrupt frame at every block joint (the eye trajectory
+  jumped up to 53.4 units, now 0.6 max), the GIF opening on an eyeless ball, and a
+  montage not starting on the resting animation fading in from it anyway.
+- **The eyes left the silhouette on non-circular shapes.** The eye is placed by a
+  pro-rata of the local body radius, which divides its margin at the edge by the same
+  factor — so the capsule, triangle, cloud and teardrop pushed it through the mask.
+  Five state × shape pairs let an eye out of the body, up to 14.5 units on a ball of
+  radius 100; now none do.
+- **A failed montage export said nothing.** The failure went to a component only
+  rendered in another view, so the progress bar vanished and nothing explained why.
+- **MP4 stayed selected on browsers that cannot encode it.** The option was hidden but
+  the value still won, and the export failed on the spot.
+- **`versMp4` leaked its encoder on failure.** Chrome caps simultaneous hardware
+  encoders, so after a few failures later exports died at startup for an unrelated
+  reason.
+- **A forbidden `localStorage` made the page blank.** Reading the property throws a
+  `SecurityError` when access is denied — blocked cookies, third-party iframe,
+  enterprise policy — and that propagated out of setup. Persistence is now optional;
+  the application never is.
+- **A hand-edited montage could freeze the tab.** 4.65 MB of JSON, inside the storage
+  budget, produced 1.5 million tick objects and a track 29 700 000 px wide.
+- **A state change landing inside a fade jumped.** The blend restarted from the full
+  pose of the state being left instead of the frame actually on screen: 26 to 43 px
+  against the 10 to 14 px a spaced change produces.
+- **Modals still slid under `prefers-reduced-motion`**, and the setting was read once at
+  startup rather than followed.
+- **Three popups declared `role="menu"` without the keyboard contract it promises**, so
+  the Tab order did not match what was announced.
+
+### Added
+
+- **Continuous integration.** There was none, so a pull request checked nothing.
+- **Cancelling a montage export.** Escape used to close the box while the export ran to
+  completion and downloaded a file nobody was waiting for.
+- **Reordering a block by keyboard** (`Alt` + arrows), the one editing gesture that had
+  no keyboard route, plus arrow keys to move the playhead.
+- **33 tests** (178 → 211), including the first that mounts the component to check the
+  off-screen render — the export defects above were invisible to everything else.
+
+### Changed
+
+- `RAYON` and `DEMI_VIEWBOX` moved to `src/bot/repere.ts`. They define what the engine
+  returns, so they could not stay in a `<script setup>` that exports nothing.
+- `MIN_BLOCK` is derived from the longest fade in the catalogue instead of written by
+  hand — it only worked because the two happened to match.
+
+### Removed
+
+- `StateDef.hint`: 15 hardcoded French strings nothing read, inside a type meant to
+  become public.
+
+[unreleased]: https://github.com/jeremy-prt/bloub/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/jeremy-prt/bloub/releases/tag/v0.1.1

--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ Props: `size`, `shape`, `color`, `expression`, `paper`, `frozenAt`, `cycle`,
 `follow`, `gaze`. Models: `block`, `state`, `playing`, `elapsed`. See
 [BloubBot.vue](src/components/BloubBot.vue) for the details.
 
+## Changes
+
+[CHANGELOG.md](CHANGELOG.md), one entry per release — which is how you tell whether the
+copy you have carries a given fix.
+
 ## License
 
 MIT. See [LICENSE](LICENSE).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bloub",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "description": "SVG recreation of the x.ai bot avatar. One shape morphing through 14 states, measured off the reference video frame by frame.",
   "license": "MIT",


### PR DESCRIPTION
The project was at `0.1.0` with no tag and no changelog. Now that people have cloned it, a release is what lets someone tell whether the copy they have carries a given fix — the export defects in particular were invisible without one.

`CHANGELOG.md` in Keep a Changelog format, `package.json` to `0.1.1`, and a pointer from the README. Every entry states what was actually reproduced and measured, not just what was touched.

A `v0.1.1` tag and a GitHub release follow this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)