### PR TITLE
interface: les vues Reglages et Animations tiennent sous 64rem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Settings and Animations views were unusable below 64rem.** Everything stacks
+  there, but three pieces were still placed as if the three-column desktop grid were
+  around them. Measured at 375 × 812: the navigation rail floated over the middle of the
+  content (over the animations panel's heading, over the avatar in Settings); the
+  montage bar had no background, so the palette scrolled through the track and its
+  labels landed on top of the zoom slider; and the wordmark sat 812 px down the
+  *document* rather than at the foot of the page, covering the credits and then drifting
+  into mid-screen once scrolled.
+- **The montage bar took 29 % of a phone screen** and its toolbar overflowed a 327 px
+  row. It is 200 px below 64rem — still the ruler plus a card at full thumbnail size —
+  the two counters flanking the play button give way to the identical pair already in
+  the toolbar, and the export button keeps its icon, its label staying as the accessible
+  name.
+
+### Changed
+
+- Below 64rem the navigation rail is a horizontal bar at the top rather than a floating
+  column on the left, and the wordmark sits in the flow at the foot of the page,
+  centred and cropped at the baseline. Above 64rem nothing moves.
+
 ## [0.1.1] — 2026-08-17
 
 First batch of post-launch fixes. Every entry was reproduced and measured before being

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,15 @@ Details and the reasoning behind each are in [docs/](docs/):
   the Tab order didn't match what was announced — they are plain button lists now, with
   `aria-haspopup="true"` and `aria-expanded`. `Settings.vue` shows the other route: a real
   `radiogroup` with a moving `tabindex`. Pick one, never the label alone.
+- **64rem is the only breakpoint, and it separates two different layouts, not two sizes.**
+  Above it the scene is the three-column grid and the page never scrolls (`#app { overflow:
+  clip }`): things can float in the margins and be anchored to the window. Below it
+  everything stacks and the page scrolls for real, which breaks exactly those three
+  assumptions — so the rail becomes a top bar, the montage bar gets an opaque background
+  (without one, content scrolls visibly through it), and the wordmark returns to the flow.
+  Anything new that is `fixed`, or anchored to the bottom of `#app`, needs its own answer
+  below 64rem. `--timeline` also changes there (236 → 200 px); the fine positioning that
+  reads it lives inside the `>= 64rem` query and never sees the other value.
 - **`prefers-reduced-motion` is followed at runtime, not read once**, and it draws a line:
   it cancels box transitions and the settings view's `swirl` entry, which are decoration;
   it does **not** cancel the breathing, gaze drift and blinking, which are what the bot IS.

--- a/src/App.vue
+++ b/src/App.vue
@@ -790,10 +790,20 @@ watch(
          des reglages, qui ne doivent pas se recentrer d'un onglet a l'autre —
          est desormais porte par ces deux colonnes elles-memes, sous la forme de
          la meme hauteur de bande (`100dvh - 3rem - var(--timeline)`). -->
+    <!-- `max-lg:px-5` : 2rem de marge laterale sur une fenetre de 375 px, c'est un
+         sixieme de la largeur pour rien. Le padding BAS n'est pas touche ici : la
+         vue Animations le remplace par la reserve de la barre de montage, et une
+         variante `max-lg:pb-*` reprendrait la main dessus. -->
     <div
-      class="scene min-h-full items-stretch justify-center p-8 max-lg:flex max-lg:flex-col max-lg:gap-10"
+      class="scene min-h-full items-stretch justify-center p-8 max-lg:flex max-lg:flex-col max-lg:gap-10 max-lg:px-5"
       :class="[
         !preview && view === 'animations' && 'pb-[calc(var(--timeline)_+_1rem)]',
+        // Sous 64rem le rail passe en bande HAUTE (cf. `SideRail`), et il flotte
+        // comme il flottait a gauche : la scene doit lui reserver sa hauteur,
+        // sinon le premier element de la pile lui passe dessous. Sauf en apercu,
+        // le seul cas ou le rail est DEMONTE — y reserver sa place descendait
+        // l'avatar de 80 px pour rien.
+        !preview && 'max-lg:pt-20',
         nue || preview ? 'scene--seule' : view === 'reglages' && 'scene--gauche'
       ]"
     >

--- a/src/components/SideRail.vue
+++ b/src/components/SideRail.vue
@@ -27,11 +27,25 @@ const muted = ref<ViewId | null>(null)
 </script>
 
 <template>
+  <!--
+    Deux dispositions, et c'est la mise en page de la page qui les impose.
+
+    A partir de 64rem la scene est une grille de trois colonnes bordee de marges
+    larges : le rail flotte dans celle de gauche sans rien recouvrir. En dessous
+    tout s'empile sur la largeur entiere, et ce meme flottement tombait en plein
+    milieu du contenu — mesure a 375 px : la pilule couvrait le titre du panneau
+    des animations et le flanc gauche de l'avatar dans les reglages.
+
+    Il passe donc en BANDE HAUTE, horizontale et centree, et la scene lui reserve
+    sa hauteur (`max-lg:pt-20` dans `App.vue`). En haut et pas en bas : la barre
+    de montage occupe deja le bas de la fenetre dans les animations, et empiler
+    les deux prenait 260 px sur 812.
+  -->
   <nav
-    class="fixed top-1/2 left-4 z-20 -translate-y-1/2 rounded-2xl border border-[var(--line)] bg-white/85 p-1.5 shadow-sm backdrop-blur"
+    class="fixed top-3 left-1/2 z-20 -translate-x-1/2 rounded-2xl border border-[var(--line)] bg-white/85 p-1.5 shadow-sm backdrop-blur lg:top-1/2 lg:left-4 lg:translate-x-0 lg:-translate-y-1/2"
     :aria-label="t('rail.nav')"
   >
-    <ul class="flex flex-col gap-1">
+    <ul class="flex gap-1 lg:flex-col">
       <li
         v-for="item in ITEMS"
         :key="item.id"
@@ -117,9 +131,16 @@ const muted = ref<ViewId | null>(null)
           `:has()`, Chromium ne reevalue pas `:focus-visible` et l'infobulle
           restait collee a l'ecran.
         -->
+        <!--
+          L'infobulle suit le rail : sous le bouton quand la barre est en haut, a
+          sa droite quand elle est sur le flanc. Elle ne fait que se FONDRE sur
+          petit ecran, la ou elle glisse a partir de 64rem : le glissement s'ecrit
+          sur `translate-x`, deja pris par le centrage horizontal en bande haute,
+          et deux valeurs sur le meme axe s'ecrasent au lieu de se composer.
+        -->
         <span
-          class="pointer-events-none absolute top-1/2 left-full z-10 ml-2 -translate-y-1/2 translate-x-1 rounded-lg bg-[var(--ink)] px-2.5 py-1.5 text-xs whitespace-nowrap text-[var(--paper)] opacity-0 transition peer-focus-visible:translate-x-0 peer-focus-visible:opacity-100 group-hover:translate-x-0 group-hover:opacity-100"
-          :class="muted === item.id && 'translate-x-1! opacity-0!'"
+          class="pointer-events-none absolute top-full left-1/2 z-10 mt-2 -translate-x-1/2 rounded-lg bg-[var(--ink)] px-2.5 py-1.5 text-xs whitespace-nowrap text-[var(--paper)] opacity-0 transition peer-focus-visible:opacity-100 group-hover:opacity-100 lg:top-1/2 lg:left-full lg:mt-0 lg:ml-2 lg:-translate-y-1/2 lg:translate-x-1 lg:peer-focus-visible:translate-x-0 lg:group-hover:translate-x-0"
+          :class="muted === item.id && 'opacity-0! lg:translate-x-1!'"
           role="tooltip"
         >
           {{ item.label }}

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -145,14 +145,29 @@ function onRemove() {
     colonne de gauche a une largeur NULLE en dehors des reglages, mais la grille
     garde son `column-gap`, donc la colonne de l'avatar commence a 72 px et non a
     32. C'est la symetrie de 24,5rem = panneau (20) + gouttiere (2,5) + marge (2).
+
+    Le FOND n'apparait que sous 64rem, et ce n'est pas un choix d'habillage.
+    Au-dessus, la page ne defile pas (`#app { overflow: clip }`) et la scene
+    reserve exactement cette bande : rien ne passe jamais derriere, donc une barre
+    transparente se lit comme une partie de la page. En dessous la page defile
+    pour de vrai, et la palette d'animations remontait mot pour mot au travers de
+    la piste — le curseur de zoom et les etiquettes des vignettes se superposaient.
+    Le filet du haut dit ou la page s'arrete de defiler.
   -->
   <div
-    class="fixed inset-x-0 bottom-0 z-30 h-[var(--timeline)] px-6 pt-3 pb-5 lg:right-[24.5rem] lg:left-[4.5rem]"
+    class="fixed inset-x-0 bottom-0 z-30 h-[var(--timeline)] px-6 pt-3 pb-5 max-lg:border-t max-lg:border-[var(--line)] max-lg:bg-[var(--paper)] max-lg:px-5 lg:right-[24.5rem] lg:left-[4.5rem]"
   >
     <!-- lecture : flottante au-dessus de la piste, au centre, le temps ecoule a
-         gauche et la duree totale a droite -->
+         gauche et la duree totale a droite.
+
+         Les deux compteurs disparaissent sous 64rem : ils depassent du haut de la
+         barre, donc du fond qui la rend lisible, et ils tombaient sur la palette
+         qui defile derriere. Le bouton, lui, reste — un disque plein se lit
+         par-dessus n'importe quoi, et il est la commande principale de la vue. La
+         meme paire de valeurs est de toute facon affichee dans la barre d'outils,
+         en bas a droite. -->
     <div class="absolute -top-5 left-1/2 flex -translate-x-1/2 items-center gap-3">
-      <span class="text-sm font-medium tabular-nums">{{ mmss(at) }}</span>
+      <span class="text-sm font-medium tabular-nums max-lg:hidden">{{ mmss(at) }}</span>
       <button
         type="button"
         class="flex h-11 w-11 cursor-pointer items-center justify-center rounded-full bg-[var(--ink)] text-[var(--paper)] shadow-sm transition hover:scale-105 active:scale-95"
@@ -182,7 +197,7 @@ function onRemove() {
           </g>
         </svg>
       </button>
-      <span class="text-sm tabular-nums text-[var(--muted)]">{{ mmss(total) }}</span>
+      <span class="text-sm tabular-nums text-[var(--muted)] max-lg:hidden">{{ mmss(total) }}</span>
     </div>
 
     <!-- rien ne se selectionne dans une barre d'outils : ca ne sert a personne
@@ -206,7 +221,7 @@ function onRemove() {
 
         <button
           type="button"
-          class="flex h-8 shrink-0 cursor-pointer items-center gap-2 rounded-xl bg-[var(--ink)] pr-3.5 pl-3 text-sm font-medium text-[var(--paper)] shadow-sm transition hover:opacity-90 active:scale-95"
+          class="flex h-8 shrink-0 cursor-pointer items-center gap-2 rounded-xl bg-[var(--ink)] pr-3.5 pl-3 text-sm font-medium text-[var(--paper)] shadow-sm transition hover:opacity-90 active:scale-95 max-sm:w-8 max-sm:justify-center max-sm:px-0"
           @click="emit('exporter')"
         >
           <!-- solar:download-minimalistic-linear, la meme que la barre d'export -->
@@ -224,7 +239,11 @@ function onRemove() {
               <path d="M12 3V16M8 11.625L12 16L16 11.625" />
             </g>
           </svg>
-          {{ t('timeline.export') }}
+          <!-- `sr-only` et pas `hidden` : sous 40rem le bouton se reduit a son
+               icone, mais le libelle reste son NOM accessible — un bouton dont
+               tout le contenu est masque n'est plus annonce du tout, et il
+               n'aurait alors ni `aria-label` ni texte. -->
+          <span class="max-sm:sr-only">{{ t('timeline.export') }}</span>
         </button>
       </div>
 
@@ -242,7 +261,7 @@ function onRemove() {
       />
 
       <!-- barre d'outils, dans le coin : loupe, compteur, aperçu -->
-      <div class="flex shrink-0 items-center justify-end gap-4">
+      <div class="flex shrink-0 items-center justify-end gap-4 max-sm:gap-2">
         <ZoomSlider v-model:zoom="zoom" :min="MIN_ZOOM" :max="MAX_ZOOM" />
 
         <p class="text-xs tabular-nums text-[var(--muted)]">

--- a/src/components/ZoomSlider.vue
+++ b/src/components/ZoomSlider.vue
@@ -26,7 +26,7 @@ function onInput(e: Event) {
     <span class="h-1 w-1 shrink-0 rounded-full bg-[var(--muted)]" aria-hidden="true" />
     <input
       type="range"
-      class="h-1 w-28 cursor-pointer accent-[var(--ink)]"
+      class="h-1 w-28 cursor-pointer accent-[var(--ink)] max-sm:w-20"
       :min="props.min"
       :max="props.max"
       step="0.01"

--- a/src/styles.css
+++ b/src/styles.css
@@ -33,6 +33,23 @@
   --bascule: 1s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
+/*
+ * La meme barre, sur une fenetre etroite : 236 px, c'est 29 % d'un ecran de
+ * telephone, et la hauteur qu'elle prend est retranchee de tout ce qui reste.
+ * 200 px laissent la regle (28 px) et des cartes de 64 px, soit la vignette a sa
+ * taille maximale — en dessous les cartes ne montrent plus rien.
+ *
+ * La variable est lue par la reserve de la scene et par le plafond de l'avatar,
+ * qui valent a toutes les largeurs. Les calages fins de `.barre-export` et des
+ * colonnes, eux, sont dans la requete `>= 64rem` : ils ne voient jamais cette
+ * valeur.
+ */
+@media (width < 64rem) {
+  :root {
+    --timeline: 200px;
+  }
+}
+
 html,
 body,
 #app {
@@ -193,6 +210,57 @@ body,
 @starting-style {
   .wordmark {
     opacity: 0;
+  }
+}
+
+/*
+ * Le mot sous 64rem : DANS LE FLUX, en bas de la page et centre.
+ *
+ * Le calage sorti du flux ne tient que tant que `#app` fait exactement la hauteur
+ * de la fenetre, ce qui est vrai au-dessus de 64rem — rien n'y defile. En dessous
+ * la page defile pour de vrai, et le mot restait a 812 px du haut du DOCUMENT :
+ * par-dessus les credits au repos (mesure a 375 px : panneau jusqu'a 780, mot des
+ * 753), puis en plein milieu de l'ecran une fois la page deroulee. Le remettre
+ * dans le flux le rend a la page : il vient apres la scene, donc en dernier, et
+ * rien ne peut plus lui passer dessus puisqu'il n'y a plus de recouvrement.
+ *
+ * Centre et non cale a gauche : les 6rem de marge degageaient le rail, qui est
+ * passe en bande HAUTE a cette largeur. Il n'y a plus rien a contourner, et un mot
+ * pleine largeur pose sous une colonne centree se lit de travers s'il ne l'est
+ * pas. La marge droite de 0,1em disparait avec le calage : le centrage laisse du
+ * jeu des deux cotes, donc le dernier B n'a plus de bord ou se couper.
+ *
+ * Le plafond descend a 200 px : sur une fenetre de tablette, 268 px de decoration
+ * mangeaient un quart de la page. Et le diviseur perd les 6rem de marge gauche,
+ * qui n'existent plus ici — le mot occupe la largeur entiere moins les gouttieres
+ * de la scene.
+ */
+@media (width < 64rem) {
+  .wordmark {
+    position: static;
+    text-align: center;
+    padding-right: 0;
+    font-size: clamp(80px, calc((100vw - 2.5rem) / 3.05), 200px);
+    /*
+     * Les lettres touchent le bord bas de la page.
+     *
+     * Une marge negative n'y suffit pas : la zone defilable est l'union des BOITES
+     * des descendants, les marges n'y entrent pas, et le talon de la fonte —
+     * l'espace des jambages, vide pour BLOUB qui n'en a aucun — depassait la boite
+     * de 21 px que la page comptait quand meme. D'ou 21 px de blanc sous le mot.
+     *
+     * On rogne donc a la LIGNE DE BASE : plus rien ne deborde, la page s'arrete ou
+     * les lettres s'arretent. C'est ce que fait le rognage de `#app` au-dessus de
+     * 64rem, ou le mot est simplement pose sous le bord.
+     */
+    height: 0.69em;
+    overflow: hidden;
+    /*
+     * Le degrade est peint sur la BOITE et revele au travers des lettres : rogner
+     * la boite l'aurait eteint plus haut (il s'annule a 88 % de sa hauteur). On lui
+     * rend donc la hauteur de la boite pleine, independamment du rognage.
+     */
+    background-size: 100% 0.78em;
   }
 }
 


### PR DESCRIPTION
Sous 64rem la mise en page s'empile et la page defile pour de vrai, mais trois
elements restaient places comme si la grille de trois colonnes etait encore
autour d'eux. Mesures a 375 x 812.

## Ce qui etait casse

| Vue | Constat | Mesure |
|---|---|---|
| Animations, Reglages | Le rail flotte sur le contenu | `fixed left-4 top-1/2` → x 16-70, y 335-477, sur le titre du panneau et sur l'avatar |
| Animations | La barre de montage n'a pas de fond | La palette defile au travers : ses etiquettes tombent sur le curseur de zoom |
| Animations | La barre prend 29 % de l'ecran | `--timeline: 236px` fixe, et sa barre d'outils deborde d'une ligne de 327 px |
| Reglages | Le mot recouvre les credits | Panneau jusqu'a y 780, mot des y 753 — puis en plein ecran une fois deroule |

## Ce que ca fait

- **Le rail passe en bande haute** sous 64rem, horizontale et centree ; la scene lui
  reserve sa hauteur, sauf en apercu ou il est demonte. L'infobulle le suit et se
  contente de se fondre : le glissement s'ecrit sur `translate-x`, deja pris par le
  centrage.
- **La barre de montage recoit un fond opaque et un filet**, et descend a 200 px —
  de quoi garder la regle et une carte a la taille maximale de vignette. Les deux
  compteurs qui debordaient du haut cedent la place a la paire identique deja
  presente dans la barre d'outils ; l'export garde son icone, son libelle restant
  son nom accessible.
- **Le grand mot revient dans le flux**, en bas de page, centre, rogne a la ligne de
  base pour que les lettres touchent le bord.

**Au-dessus de 64rem, rien ne bouge** : verifie a 1440 x 900, le mot est toujours
`absolute` a `left: 96px` sur 209 px de haut, le rail toujours vertical a gauche,
la barre toujours transparente avec ses deux compteurs.

`pnpm build` passe, 211 tests passent, `video-*.js` toujours a 0,77 ko.